### PR TITLE
Block anonymous data owners from accessing occurrences methods

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ContactLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ContactLogicImpl.kt
@@ -230,6 +230,9 @@ open class ContactLogicImpl(
 		codeType: String,
 		minOccurences: Long,
 	): List<LabelledOccurence> {
+		require(getAllSearchKeysIfCurrentDataOwner(hcPartyId).size <= 1) {
+			"This method is not supported for anonymous data owners"
+		}
 		val datastoreInformation = getInstanceAndGroup()
 		val mapped = contactDAO.listCodesFrequencies(datastoreInformation, hcPartyId, codeType)
 			.filter { v -> v.second?.let { it >= minOccurences } == true }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/InvoiceLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/InvoiceLogicImpl.kt
@@ -421,6 +421,9 @@ open class InvoiceLogicImpl (
 
 
 	override suspend fun getTarificationsCodesOccurrences(hcPartyId: String, minOccurrences: Long): List<LabelledOccurence> {
+		require(getAllSearchKeysIfCurrentDataOwner(hcPartyId).size <= 1) {
+			"This method is not supported for anonymous data owners"
+		}
 		val datastoreInformation = getInstanceAndGroup()
 		return invoiceDAO.listTarificationsFrequencies(datastoreInformation, hcPartyId)
 			.filter { v -> v.value != null && v.value!! >= minOccurrences  && v.key != null && v.key!!.components.size > 1 && v.key!!.components[1] != null }


### PR DESCRIPTION
The code occurrences method does not currently support anonymous data owners.

In general, even updating this method to support anonymous data owners would give inaccurate results in case of occasional double sharing to the same anonymous data owner.

Since this method was not intended for use by patients it is probably better to just block usage by anonymous data owners rather than returning inaccurate results.