### PR TITLE
Deprecate form template by specialty and guuid

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/FormController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/FormController.kt
@@ -277,6 +277,7 @@ class FormController(
 
 	@Operation(summary = "Gets a form template")
 	@GetMapping("/template/{specialityCode}/guid/{formTemplateGuid}")
+	@Deprecated("This method has unintuitive behaviour, read FormTemplateService.getFormTemplatesByGuid doc for more info")
 	fun getFormTemplatesByGuid(@PathVariable formTemplateGuid: String, @PathVariable specialityCode: String, @RequestParam(required = false) raw: Boolean?): Flux<FormTemplateDto> = flow {
 		emitAll(
 			formTemplateService.getFormTemplatesByGuid(sessionLogic.getCurrentUserId(), specialityCode, formTemplateGuid)

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/FormController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/FormController.kt
@@ -309,6 +309,7 @@ class FormController(
 
 	@Operation(summary = "Gets a form template")
 	@GetMapping("/template/{specialityCode}/guid/{formTemplateGuid}")
+	@Deprecated("This method has unintuitive behaviour, read FormTemplateService.getFormTemplatesByGuid doc for more info")
 	fun getFormTemplatesByGuid(@PathVariable formTemplateGuid: String, @PathVariable specialityCode: String, @RequestParam(required = false) raw: Boolean?): Flux<FormTemplateDto> = flow {
 		emitAll(
 			formTemplateService.getFormTemplatesByGuid(sessionLogic.getCurrentUserId(), specialityCode, formTemplateGuid)

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/FormTemplateLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/FormTemplateLogic.kt
@@ -13,6 +13,7 @@ interface FormTemplateLogic : EntityPersister<FormTemplate> {
     suspend fun createFormTemplate(entity: FormTemplate): FormTemplate
 
     suspend fun getFormTemplate(formTemplateId: String): FormTemplate?
+    @Deprecated("This method has unintuitive behaviour, read FormTemplateService.getFormTemplatesByGuid doc for more info")
     fun getFormTemplatesByGuid(userId: String, specialityCode: String, formTemplateGuid: String): Flow<FormTemplate>
     fun getFormTemplatesBySpecialty(specialityCode: String, loadLayout: Boolean): Flow<FormTemplate>
     fun getFormTemplatesByUser(userId: String, loadLayout: Boolean): Flow<FormTemplate>

--- a/service/src/main/kotlin/org/taktik/icure/asyncservice/FormTemplateService.kt
+++ b/service/src/main/kotlin/org/taktik/icure/asyncservice/FormTemplateService.kt
@@ -12,6 +12,13 @@ interface FormTemplateService {
 	fun createFormTemplates(entities: Collection<FormTemplate>, createdEntities: Collection<FormTemplate>): Flow<FormTemplate>
 	suspend fun createFormTemplate(entity: FormTemplate): FormTemplate
 	suspend fun getFormTemplate(formTemplateId: String): FormTemplate?
+	/**
+	 * If there is any form template with author=[userId] and guid=[formTemplateGuid] returns them, regardless of
+	 * [specialityCode].
+	 * Else returns all form templates with specialty.code=[specialityCode] and guid=[formTemplateGuid] regardless of
+	 * [userId].
+	 */
+	@Deprecated("This method has unintuitive behaviour, read FormTemplateService.getFormTemplatesByGuid doc for more info")
 	fun getFormTemplatesByGuid(userId: String, specialityCode: String, formTemplateGuid: String): Flow<FormTemplate>
 	fun getFormTemplatesBySpecialty(specialityCode: String, loadLayout: Boolean): Flow<FormTemplate>
 	fun getFormTemplatesByUser(userId: String, loadLayout: Boolean): Flow<FormTemplate>


### PR DESCRIPTION
Deprecates `getFormTemplatesByGuid` method / `/template/{specialityCode}/guid/{formTemplateGuid}` endpoint as unintuitive.

Safer implementation in case we switch in future to non-cached flows for web requests.

