### PR TITLE
Removed inline from utility function in Patient Controller

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/PatientController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/PatientController.kt
@@ -488,9 +488,9 @@ class PatientController(
 	fun createPatientsFull(@RequestBody patientDtos: List<PatientDto>): Flux<PatientDto> =
 		doCreatePatients(patientDtos, patientV2Mapper::map)
 
-	private inline fun <T : Any> doCreatePatients(
+	private fun <T : Any> doCreatePatients(
 		patientDtos: List<PatientDto>,
-		crossinline mapResult: (Patient) -> T
+		mapResult: (Patient) -> T
 	): Flux<T> =
 		flow {
 			val patients = patientService.createPatients(patientDtos.map { p -> patientV2Mapper.map(p) }.toList())

--- a/jwt/src/main/kotlin/org/taktik/icure/properties/AuthProperties.kt
+++ b/jwt/src/main/kotlin/org/taktik/icure/properties/AuthProperties.kt
@@ -1,9 +1,5 @@
 package org.taktik.icure.properties
 
-import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.context.annotation.Profile
-import org.springframework.stereotype.Component
-
 interface AuthProperties {
 	val jwt: Jwt
 	val validationSkewSeconds: Long


### PR DESCRIPTION
Having that function to be inlined with a crossinline lambda causes a NullPointer exception on the lambda for some obscure reason.