### PR TITLE
Make omit other encryption keys on secure delegation optional

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/PatientController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/PatientController.kt
@@ -548,7 +548,7 @@ class PatientController(
 		require(intoId == updatedInto.id) {
 			"The id of the `into` patient in the path variable must be the same as the id of the `into` patient in the request body"
 		}
-		patientMapper.map(patientService.mergePatients(fromId, expectedFromRev, patientMapper.map(updatedInto)))
+		patientMapper.map(patientService.mergePatients(fromId, expectedFromRev, patientMapper.map(updatedInto), true))
 	}
 
 	companion object {

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/PatientController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/PatientController.kt
@@ -622,12 +622,14 @@ class PatientController(
 			"result of the merge of the `from` and `into` patients according to the patient logic. The metadata will" +
 			"be automatically merged by this method.")
 		@RequestBody
-		updatedInto: PatientDto
+		updatedInto: PatientDto,
+		@RequestParam(required = false)
+		omitEncryptionKeysOfFrom: Boolean? = null,
 	): Mono<PatientDto> = mono {
 		require(intoId == updatedInto.id) {
 			"The id of the `into` patient in the path variable must be the same as the id of the `into` patient in the request body"
 		}
-		patientV2Mapper.map(patientService.mergePatients(fromId, expectedFromRev, patientV2Mapper.map(updatedInto)))
+		patientV2Mapper.map(patientService.mergePatients(fromId, expectedFromRev, patientV2Mapper.map(updatedInto), omitEncryptionKeysOfFrom ?: true))
 	}
 
 	companion object {

--- a/domain/src/main/kotlin/org/taktik/icure/entities/embed/SecurityMetadata.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/embed/SecurityMetadata.kt
@@ -64,14 +64,14 @@ data class SecurityMetadata(
         other: SecurityMetadata,
         mergeVersions: Boolean
     ): SecurityMetadata {
-        // 2. Find duplicate delegations and merge
+        // Find duplicate delegations and merge
         val mergedDelegations = (this.secureDelegations.keys + other.secureDelegations.keys).associateWith { canonicalKey ->
             val thisDelegation = this.secureDelegations[canonicalKey]
             val otherDelegation = other.secureDelegations[canonicalKey]
             if (thisDelegation != null && otherDelegation != null)
                 mergeSecDels(thisDelegation, otherDelegation, mergeVersions)
             else
-                checkNotNull(thisDelegation ?: otherDelegation) {
+                checkNotNull(thisDelegation ?: otherDelegation?.copy(encryptionKeys = emptySet())) {
                     "At least one of the delegations should have been not null"
                 }
         }

--- a/domain/src/main/kotlin/org/taktik/icure/entities/embed/SecurityMetadata.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/embed/SecurityMetadata.kt
@@ -40,7 +40,11 @@ data class SecurityMetadata(
      * @param other the security metadata of the other version of the entity.
      * @return the merged security metadata.
      */
-    fun mergeForDifferentVersionsOfEntity(other: SecurityMetadata): SecurityMetadata = merge(other, true)
+    fun mergeForDifferentVersionsOfEntity(other: SecurityMetadata): SecurityMetadata = merge(
+		other = other,
+		mergeVersions = true,
+		omitEncryptionKeysOfOther = false
+	)
 
     /**
      * Merges the security metadata of duplicated entities (e.g. different patient entities representing the same
@@ -49,7 +53,7 @@ data class SecurityMetadata(
      * revision history): use [mergeForDifferentVersionsOfEntity] instead.
      * The main differences with [mergeForDifferentVersionsOfEntity] are:
      * - This method is not commutative
-     * - The encrypted encryption keys from delegations of [other] will not be merged into this.
+     * - The encrypted encryption keys from delegations of [other] can be omitted.
      * - The parents of equivalent delegations are merged as follows:
      *   - If a delegation is root in this and/or other it will be a root delegation in the merged metadata as
      *     well (potentially removing links which exist in one of the delegations).
@@ -58,18 +62,31 @@ data class SecurityMetadata(
      * @param other the security metadata of the duplicated entity.
      * @return a new security metadata being the result of the merging.
      */
-    fun mergeForDuplicatedEntityIntoThisFrom(other: SecurityMetadata): SecurityMetadata = merge(other, false)
+    fun mergeForDuplicatedEntityIntoThisFrom(
+        other: SecurityMetadata,
+        omitEncryptionKeysOfOther: Boolean
+    ): SecurityMetadata = merge(
+		other = other,
+		mergeVersions = false,
+		omitEncryptionKeysOfOther = omitEncryptionKeysOfOther
+	)
 
     private fun merge(
         other: SecurityMetadata,
-        mergeVersions: Boolean
+        mergeVersions: Boolean,
+        omitEncryptionKeysOfOther: Boolean
     ): SecurityMetadata {
         // Find duplicate delegations and merge
         val mergedDelegations = (this.secureDelegations.keys + other.secureDelegations.keys).associateWith { canonicalKey ->
             val thisDelegation = this.secureDelegations[canonicalKey]
             val otherDelegation = other.secureDelegations[canonicalKey]
             if (thisDelegation != null && otherDelegation != null)
-                mergeSecDels(thisDelegation, otherDelegation, mergeVersions)
+                mergeSecDels(
+					thisDelegation = thisDelegation,
+					otherDelegation = otherDelegation,
+					mergeVersions = mergeVersions,
+					omitEncryptionKeysOfOther = omitEncryptionKeysOfOther
+				)
             else
                 checkNotNull(thisDelegation ?: otherDelegation?.copy(encryptionKeys = emptySet())) {
                     "At least one of the delegations should have been not null"
@@ -83,7 +100,8 @@ data class SecurityMetadata(
     private fun mergeSecDels(
         thisDelegation: SecureDelegation,
         otherDelegation: SecureDelegation,
-        mergeVersions: Boolean
+        mergeVersions: Boolean,
+        omitEncryptionKeysOfOther: Boolean
     ): SecureDelegation {
         if (
             thisDelegation.delegator != otherDelegation.delegator
@@ -96,10 +114,10 @@ data class SecurityMetadata(
             delegator = thisDelegation.delegator,
             delegate = thisDelegation.delegate,
             secretIds = thisDelegation.secretIds + otherDelegation.secretIds,
-            encryptionKeys = if (mergeVersions) {
-                thisDelegation.encryptionKeys + otherDelegation.encryptionKeys
-            } else {
+            encryptionKeys = if (omitEncryptionKeysOfOther) {
                 thisDelegation.encryptionKeys
+            } else {
+                thisDelegation.encryptionKeys + otherDelegation.encryptionKeys
             },
             owningEntityIds = thisDelegation.owningEntityIds + otherDelegation.owningEntityIds,
             parentDelegations = if (mergeVersions) {

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/PatientLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/PatientLogic.kt
@@ -211,6 +211,10 @@ interface PatientLogic: EntityPersister<Patient>, EntityWithSecureDelegationsLog
 	 * @throws ConflictRequestException if the [expectedFromRev] or [updatedInto] revision does not match the actual
 	 * revisions of the respective patients.
 	 */
-	suspend fun mergePatients(fromId: String, expectedFromRev: String, updatedInto: Patient): Patient
-
+	suspend fun mergePatients(
+		fromId: String,
+		expectedFromRev: String,
+		updatedInto: Patient,
+		omitEncryptionKeysOfFrom: Boolean,
+	): Patient
 }

--- a/service/src/main/kotlin/org/taktik/icure/asyncservice/PatientService.kt
+++ b/service/src/main/kotlin/org/taktik/icure/asyncservice/PatientService.kt
@@ -247,7 +247,12 @@ interface PatientService : EntityWithSecureDelegationsService<Patient>, EntityWi
 	 * revisions of the respective patients.
 	 * @throws AccessDeniedException if the current user does not have write rights to the `into` and/or `from` patient.
 	 */
-	suspend fun mergePatients(fromId: String, expectedFromRev: String, updatedInto: Patient): Patient
+	suspend fun mergePatients(
+		fromId: String,
+		expectedFromRev: String,
+		updatedInto: Patient,
+		omitEncryptionKeysOfFrom: Boolean,
+	): Patient
 
 	/**
 	 * Retrieves the ids of the [Patient]s matching the provided [filter].


### PR DESCRIPTION
When merging an entity X into an entity Y the content of entity Y will normally be encrypted with the key of Y.
This means that normally the encryption keys from entity X should be completely removed from the merged entity (while other information like owning entity id and secret ids should be kept)

However it could be possible to have a requirement to merge entity X with Y while not decrypting either of them. In those cases since different parts of the entity could be encrypted with different keys all encryption keys should be kept. 

This PR:
- Allows to specify if the encryption keys should be omitted (defaults to true)
- Fixes a bug where encryption keys were not omitted under some circumstances.