### PR TITLE
Reuse codec instead of instantiating new object mapper

### DIFF
--- a/domain/src/main/kotlin/org/taktik/icure/handlers/JacksonLenientCollectionDeserializer.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/handlers/JacksonLenientCollectionDeserializer.kt
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer
 import com.fasterxml.jackson.databind.node.ArrayNode
 
+/**
+ * De-serializer that ignores null values in lists
+ */
 class JacksonLenientCollectionDeserializer(
 	private val collectionType: JavaType? = null,
 	val elementType: JavaType? = null,

--- a/domain/src/main/kotlin/org/taktik/icure/handlers/JacksonLenientCollectionDeserializer.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/handlers/JacksonLenientCollectionDeserializer.kt
@@ -15,19 +15,20 @@ class JacksonLenientCollectionDeserializer(
 ) : JsonDeserializer<Collection<*>>(),
 	ContextualDeserializer {
 
-	val mapper: ObjectMapper by lazy { ObjectMapper() }
-
-	override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Collection<*> = p.readValueAsTree<ArrayNode>()
-		.filter { !it.isNull }
-		.map {
-			mapper.treeToValue(it, elementType?.rawClass)
-		}.let {
-			when (collectionType?.rawClass?.simpleName) {
-				"Set" -> it.toSet()
-				"List" -> it.toList()
-				else -> it
+	override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Collection<*> {
+		val mapper = p.codec
+		return p.readValueAsTree<ArrayNode>()
+			.filter { !it.isNull }
+			.map {
+				mapper.treeToValue(it, elementType?.rawClass)
+			}.let {
+				when (collectionType?.rawClass?.simpleName) {
+					"Set" -> it.toSet()
+					"List" -> it.toList()
+					else -> it
+				}
 			}
-		}
+	}
 
 	override fun createContextual(ctxt: DeserializationContext?, property: BeanProperty?): JsonDeserializer<*> = JacksonLenientCollectionDeserializer(
 		property?.type,


### PR DESCRIPTION
Jira: [ICBE-403](https://icure.atlassian.net/browse/ICBE-403)

Since the current implementation instantiates a local ObjectMapper it ignores any configuration on it.

The new implementation reuses the mapper, ensuring that all configurations are respected.

Tested on cloud

[ICBE-403]: https://icure.atlassian.net/browse/ICBE-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ