### PR TITLE
Add publicProperties to HCP and CalendarItemType entities

### DIFF
--- a/domain/src/main/kotlin/org/taktik/icure/entities/CalendarItemType.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/CalendarItemType.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import org.taktik.couchdb.entity.Attachment
 import org.taktik.icure.annotations.entities.ContentValue
 import org.taktik.icure.annotations.entities.ContentValues
+import org.taktik.icure.entities.base.PropertyStub
 import org.taktik.icure.entities.base.StoredDocument
 import org.taktik.icure.entities.embed.RevisionInfo
 import org.taktik.icure.utils.DynamicInitializer
@@ -34,6 +35,10 @@ data class CalendarItemType(
 	val docIds: Set<String> = emptySet(),
 	val otherInfos: Map<String, String> = emptyMap(),
 	val subjectByLanguage: Map<String, String> = emptyMap(),
+	/**
+	 * Public properties of public calendar items (i.e. calendar items available in public timetableitems) are exposed to anonymous endpoints.
+	 */
+	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val publicProperties: Set<PropertyStub>? = null,
 	@param:JsonProperty("_attachments") override val attachments: Map<String, Attachment>? = null,
 	@param:JsonProperty("_revs_info") override val revisionsInfo: List<RevisionInfo>? = null,
 	@param:JsonProperty("_conflicts") override val conflicts: List<String>? = null,

--- a/domain/src/main/kotlin/org/taktik/icure/entities/HealthcareParty.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/HealthcareParty.kt
@@ -148,8 +148,13 @@ data class HealthcareParty(
 	/**
 	 * If set to true the healthcare party is considered public, and a stripped down version of the healthcare party
 	 * will be accessible through the anonymous endpoints.
+	 * TODO added for the future but currently unused
 	 */
 	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val public: Boolean = false,
+	/**
+	 * Public properties are exposed to all users and anonymous endpoints.
+	 */
+	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val publicProperties: Set<PropertyStub>? = null,
 	// One AES key per HcParty, encrypted using this hcParty public key and the other hcParty public key
 	// For a pair of HcParties, this key is called the AES exchange key
 	// Each HcParty always has one AES exchange key for himself

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CalendarItemTypeDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CalendarItemTypeDto.kt
@@ -42,6 +42,7 @@ data class CalendarItemTypeDto(
 	val docIds: Set<String> = emptySet(),
 	val otherInfos: Map<String, String> = emptyMap(),
 	val subjectByLanguage: Map<String, String> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val publicProperties: Set<PropertyStubDto>? = null,
 ) : StoredDocumentDto {
 	override fun withIdRev(
 		id: String?,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthcarePartyDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthcarePartyDto.kt
@@ -121,6 +121,7 @@ data class HealthcarePartyDto(
 	val options: Map<String, String> = emptyMap(),
 	override val properties: Set<PropertyStubDto> = emptySet(),
 	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val public: Boolean = false,
+	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val publicProperties: Set<PropertyStubDto>? = null,
 	override val cryptoActorProperties: Set<PropertyStubDto>? = null,
 	override val hcPartyKeys: Map<String, List<HexStringDto>> = emptyMap(),
 	override val aesExchangeKeys: Map<AesExchangeKeyEntryKeyStringDto, Map<String, Map<AesExchangeKeyEncryptionKeypairIdentifierDto, HexStringDto>>> = emptyMap(),

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/CalendarItemTypeMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/CalendarItemTypeMapper.kt
@@ -19,6 +19,7 @@ interface CalendarItemTypeMapper {
 		Mapping(target = "revHistory", ignore = true),
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
+		Mapping(target = "publicProperties", ignore = true),
 	)
 	fun map(calendarItemTypeDto: CalendarItemTypeDto): CalendarItemType
 	fun map(calendarItemType: CalendarItemType): CalendarItemTypeDto

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/HealthcarePartyMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/HealthcarePartyMapper.kt
@@ -26,6 +26,7 @@ interface HealthcarePartyMapper {
 		Mapping(target = "revHistory", ignore = true),
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
+		Mapping(target = "publicProperties", ignore = true),
 	)
 	fun map(healthcarePartyDto: HealthcarePartyDto): HealthcareParty
 	fun map(healthcareParty: HealthcareParty): HealthcarePartyDto

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/CalendarItemTypeMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/CalendarItemTypeMapper.kt
@@ -24,9 +24,10 @@ import org.mapstruct.Mapping
 import org.mapstruct.Mappings
 import org.taktik.icure.entities.CalendarItemType
 import org.taktik.icure.services.external.rest.v2.dto.CalendarItemTypeDto
+import org.taktik.icure.services.external.rest.v2.mapper.base.PropertyStubV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.DurationConfigV2Mapper
 
-@Mapper(componentModel = "spring", uses = [DurationConfigV2Mapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper(componentModel = "spring", uses = [DurationConfigV2Mapper::class, PropertyStubV2Mapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 interface CalendarItemTypeV2Mapper {
 	@Mappings(
 		Mapping(target = "attachments", ignore = true),


### PR DESCRIPTION
Jira: [ICBE-479](https://icure.atlassian.net/browse/ICBE-479)

Add `publicProperties` field to HealthcareParty and CalendarItemType entities.
This field is returned by all anonymous methods, and in the case of HCP by authenticated methods regardless of permissions.

[ICBE-479]: https://icure.atlassian.net/browse/ICBE-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ