### PR TITLE
feat: Replace Contact's participants by participantList

### DIFF
--- a/domain/src/main/kotlin/org/taktik/icure/entities/Contact.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/Contact.kt
@@ -16,6 +16,7 @@ import org.taktik.icure.entities.base.ParticipantType
 import org.taktik.icure.entities.base.StoredICureDocument
 import org.taktik.icure.entities.embed.Address
 import org.taktik.icure.entities.embed.Annotation
+import org.taktik.icure.entities.embed.ContactParticipant
 import org.taktik.icure.entities.embed.Delegation
 import org.taktik.icure.entities.embed.Encryptable
 import org.taktik.icure.entities.embed.Identifier
@@ -103,7 +104,9 @@ data class Contact(
 	val encounterLocation: Address? = null,
 	@param:ContentValue(ContentValues.NESTED_ENTITIES_SET) @field:Valid val subContacts: Set<SubContact> = emptySet(),
 	@param:ContentValue(ContentValues.NESTED_ENTITIES_SET) @field:Valid val services: Set<Service> = emptySet(),
+	@Deprecated("Replaced by participantList", replaceWith = ReplaceWith("participantList"))
 	val participants: Map<ParticipantType, String> = emptyMap(),
+	val participantList: List<ContactParticipant> = emptyList(),
 
 	override val secretForeignKeys: Set<String> = emptySet(),
 	override val cryptedForeignKeys: Map<String, Set<Delegation>> = emptyMap(),

--- a/domain/src/main/kotlin/org/taktik/icure/entities/Contact.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/Contact.kt
@@ -6,13 +6,13 @@ package org.taktik.icure.entities
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import jakarta.validation.Valid
 import org.taktik.couchdb.entity.Attachment
 import org.taktik.icure.annotations.entities.ContentValue
 import org.taktik.icure.annotations.entities.ContentValues
 import org.taktik.icure.entities.base.CodeStub
 import org.taktik.icure.entities.base.HasEncryptionMetadata
-import org.taktik.icure.entities.base.ParticipantType
 import org.taktik.icure.entities.base.StoredICureDocument
 import org.taktik.icure.entities.embed.Address
 import org.taktik.icure.entities.embed.Annotation
@@ -26,6 +26,7 @@ import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.entities.embed.ServiceLink
 import org.taktik.icure.entities.embed.SubContact
 import org.taktik.icure.entities.utils.MergeUtil.mergeSets
+import org.taktik.icure.serializers.ParticipantListSerializer
 import org.taktik.icure.utils.DynamicInitializer
 import org.taktik.icure.utils.invoke
 import org.taktik.icure.validation.AutoFix
@@ -104,9 +105,7 @@ data class Contact(
 	val encounterLocation: Address? = null,
 	@param:ContentValue(ContentValues.NESTED_ENTITIES_SET) @field:Valid val subContacts: Set<SubContact> = emptySet(),
 	@param:ContentValue(ContentValues.NESTED_ENTITIES_SET) @field:Valid val services: Set<Service> = emptySet(),
-	@Deprecated("Replaced by participantList", replaceWith = ReplaceWith("participantList"))
-	val participants: Map<ParticipantType, String> = emptyMap(),
-	val participantList: List<ContactParticipant> = emptyList(),
+	@JsonDeserialize(using = ParticipantListSerializer::class) val participants: List<ContactParticipant> = emptyList(),
 
 	override val secretForeignKeys: Set<String> = emptySet(),
 	override val cryptedForeignKeys: Map<String, Set<Delegation>> = emptyMap(),

--- a/domain/src/main/kotlin/org/taktik/icure/entities/base/ParticipantType.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/base/ParticipantType.kt
@@ -56,11 +56,17 @@ enum class ParticipantType {
 	@JsonProperty("secondaryPerformer")
 	SecondaryPerformer,
 
+	@JsonProperty("secondaryPerformerOrganization")
+	SecondaryPerformerOrganization,
+
 	/**
 	 * The principal or primary performer of the act.
 	 */
 	@JsonProperty("primaryPerformer")
 	PrimaryPerformer,
+
+	@JsonProperty("primaryPerformerOrganization")
+	PrimaryPerformerOrganization,
 
 	/**
 	 * Indicates that the target of the participation is involved in some manner in the act, but does not qualify how.
@@ -85,4 +91,10 @@ enum class ParticipantType {
 	 */
 	@JsonProperty("location")
 	Location,
+
+	@JsonProperty("recorder")
+	Recorder,
+
+	@JsonProperty("recorderOrganization")
+	RecorderOrganization,
 }

--- a/domain/src/main/kotlin/org/taktik/icure/entities/base/ParticipantType.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/base/ParticipantType.kt
@@ -56,17 +56,11 @@ enum class ParticipantType {
 	@JsonProperty("secondaryPerformer")
 	SecondaryPerformer,
 
-	@JsonProperty("secondaryPerformerOrganization")
-	SecondaryPerformerOrganization,
-
 	/**
 	 * The principal or primary performer of the act.
 	 */
 	@JsonProperty("primaryPerformer")
 	PrimaryPerformer,
-
-	@JsonProperty("primaryPerformerOrganization")
-	PrimaryPerformerOrganization,
 
 	/**
 	 * Indicates that the target of the participation is involved in some manner in the act, but does not qualify how.
@@ -94,7 +88,4 @@ enum class ParticipantType {
 
 	@JsonProperty("recorder")
 	Recorder,
-
-	@JsonProperty("recorderOrganization")
-	RecorderOrganization,
 }

--- a/domain/src/main/kotlin/org/taktik/icure/entities/base/ParticipantType.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/base/ParticipantType.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 /**
  * Enum class representing the participant types for an encounter/contact
  *
- * Mostly based on HL7 FHIR R4
  */
 enum class ParticipantType {
 	/**

--- a/domain/src/main/kotlin/org/taktik/icure/entities/embed/ContactParticipant.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/embed/ContactParticipant.kt
@@ -8,6 +8,5 @@ import org.taktik.icure.entities.base.ParticipantType
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ContactParticipant(
 	val type: ParticipantType,
-	val practitionerId: String? = null,
-	val organizationId: String? = null,
+	val hcpId: String,
 )

--- a/domain/src/main/kotlin/org/taktik/icure/entities/embed/ContactParticipant.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/embed/ContactParticipant.kt
@@ -8,5 +8,6 @@ import org.taktik.icure.entities.base.ParticipantType
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ContactParticipant(
 	val type: ParticipantType,
-	val referenceId: String
+	val practitionerId: String? = null,
+	val organizationId: String? = null,
 )

--- a/domain/src/main/kotlin/org/taktik/icure/entities/embed/ContactParticipant.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/embed/ContactParticipant.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.entities.embed
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import org.taktik.icure.entities.base.ParticipantType
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ContactParticipant(
+	val type: ParticipantType,
+	val referenceId: String
+)

--- a/domain/src/main/kotlin/org/taktik/icure/serializers/ParticipantListSerializer.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/serializers/ParticipantListSerializer.kt
@@ -1,0 +1,34 @@
+package org.taktik.icure.serializers
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.taktik.icure.entities.base.ParticipantType
+import org.taktik.icure.entities.embed.ContactParticipant
+
+class ParticipantListSerializer: JsonDeserializer<Collection<ContactParticipant>>() {
+	override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): Collection<ContactParticipant> {
+		return when (val node = p.readValueAsTree<JsonNode>()) {
+			is ArrayNode -> {
+				// Should be a list of ContactParticipant
+				node.map {
+					p.codec.treeToValue(it, ContactParticipant::class.java)
+				}
+			}
+			is ObjectNode -> {
+				// Should be a Map<ParticipantType, String>
+
+				node.properties().map { (k, v) ->
+					ContactParticipant(
+						type = ParticipantType.valueOf(k),
+						hcpId = v.asText()
+					)
+				}.toList()
+			}
+			else -> throw IllegalArgumentException("Expected array or object, got $node")
+		}
+	}
+}

--- a/domain/src/main/kotlin/org/taktik/icure/serializers/ParticipantListSerializer.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/serializers/ParticipantListSerializer.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
 import org.taktik.icure.entities.base.ParticipantType
 import org.taktik.icure.entities.embed.ContactParticipant
 
@@ -23,7 +24,7 @@ class ParticipantListSerializer: JsonDeserializer<Collection<ContactParticipant>
 
 				node.properties().map { (k, v) ->
 					ContactParticipant(
-						type = ParticipantType.valueOf(k),
+						type = p.codec.treeToValue(TextNode(k), ParticipantType::class.java),
 						hcpId = v.asText()
 					)
 				}.toList()

--- a/domain/src/test/kotlin/org/taktik/icure/serializers/ParticipantListSerializerTest.kt
+++ b/domain/src/test/kotlin/org/taktik/icure/serializers/ParticipantListSerializerTest.kt
@@ -1,0 +1,196 @@
+package org.taktik.icure.serializers
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.json.JsonReadFeature
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.taktik.icure.entities.base.ParticipantType
+import org.taktik.icure.entities.embed.ContactParticipant
+
+private data class TestParticipantEntity(
+	val id: String,
+	@param:JsonDeserialize(using = ParticipantListSerializer::class)
+	val participants: Collection<ContactParticipant>,
+)
+
+class ParticipantListSerializerTest :
+	StringSpec({
+		val mapper = ObjectMapper().registerModule(
+			KotlinModule.Builder()
+				.configure(KotlinFeature.NullIsSameAsDefault, true)
+				.configure(KotlinFeature.NullToEmptyMap, true)
+				.configure(KotlinFeature.NullToEmptyCollection, true)
+				.build(),
+		).apply {
+			setSerializationInclusion(JsonInclude.Include.NON_NULL)
+			configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature(), true)
+		}
+
+		"Deserialization of JSON with array of ContactParticipant objects" {
+			val json = """
+            {
+                "id": "entity1",
+                "participants": [
+                    {
+                        "type": "admitter",
+                        "hcpId": "hcp-001"
+                    },
+					{
+                        "type": "attender",
+                        "hcpId": "hcp-002"
+                    },
+                    {
+                        "type": "consultant",
+                        "hcpId": "hcp-003"
+                    },
+					{
+                        "type": "admitter",
+                        "hcpId": "hcp-004"
+                    }
+                ]
+            }
+			""".trimIndent()
+
+			val result = mapper.readValue<TestParticipantEntity>(json)
+
+			result.id shouldBe "entity1"
+			result.participants.size shouldBe 4
+			result.participants shouldContainExactlyInAnyOrder listOf(
+				ContactParticipant(type = ParticipantType.Admitter, hcpId = "hcp-001"),
+				ContactParticipant(type = ParticipantType.Attender, hcpId = "hcp-002"),
+				ContactParticipant(type = ParticipantType.Consultant, hcpId = "hcp-003"),
+				ContactParticipant(type = ParticipantType.Admitter, hcpId = "hcp-004"),
+			)
+		}
+
+		"Deserialization of JSON with object (legacy Map format)" {
+			val json = """
+            {
+                "id": "entity2",
+                "participants": {
+                    "admitter": "hcp-001",
+                    "referrer": "hcp-004",
+                    "discharger": "hcp-005"
+                }
+            }
+			""".trimIndent()
+
+			val result = mapper.readValue<TestParticipantEntity>(json)
+
+			result.id shouldBe "entity2"
+			result.participants.size shouldBe 3
+			result.participants shouldContainExactlyInAnyOrder listOf(
+				ContactParticipant(type = ParticipantType.Admitter, hcpId = "hcp-001"),
+				ContactParticipant(type = ParticipantType.Referrer, hcpId = "hcp-004"),
+				ContactParticipant(type = ParticipantType.Discharger, hcpId = "hcp-005"),
+			)
+		}
+
+		"Deserialization of empty array" {
+			val json = """
+            {
+                "id": "entity3",
+                "participants": []
+            }
+			""".trimIndent()
+
+			val result = mapper.readValue<TestParticipantEntity>(json)
+
+			result.id shouldBe "entity3"
+			result.participants.size shouldBe 0
+		}
+
+		"Deserialization of empty object" {
+			val json = """
+            {
+                "id": "entity4",
+                "participants": {}
+            }
+			""".trimIndent()
+
+			val result = mapper.readValue<TestParticipantEntity>(json)
+
+			result.id shouldBe "entity4"
+			result.participants.size shouldBe 0
+		}
+
+		"Deserialization with all ParticipantType values in object format" {
+			val json = """
+            {
+                "id": "entity5",
+                "participants": {
+					"admitter": "hcp-admitter",
+					"attender": "hcp-attender",
+					"callback": "hcp-callback",
+					"consultant": "hcp-consultant",
+					"discharger": "hcp-discharger",
+					"escort": "hcp-escort",
+					"referrer": "hcp-referrer",
+					"secondaryPerformer": "hcp-secondaryPerformer",
+					"primaryPerformer": "hcp-primaryPerformer",
+					"participation": "hcp-participation",
+					"translator": "hcp-translator",
+					"emergency": "hcp-emergency",
+					"location": "hcp-location",
+					"recorder": "hcp-recorder"
+                }
+            }
+			""".trimIndent()
+
+			val result = mapper.readValue<TestParticipantEntity>(json)
+
+			result.id shouldBe "entity5"
+			result.participants.size shouldBe 14
+			result.participants shouldContainExactlyInAnyOrder listOf(
+				ContactParticipant(type = ParticipantType.Admitter, hcpId = "hcp-admitter"),
+				ContactParticipant(type = ParticipantType.Attender, hcpId = "hcp-attender"),
+				ContactParticipant(type = ParticipantType.CallbackContact, hcpId = "hcp-callback"),
+				ContactParticipant(type = ParticipantType.Consultant, hcpId = "hcp-consultant"),
+				ContactParticipant(type = ParticipantType.Discharger, hcpId = "hcp-discharger"),
+				ContactParticipant(type = ParticipantType.Escort, hcpId = "hcp-escort"),
+				ContactParticipant(type = ParticipantType.Referrer, hcpId = "hcp-referrer"),
+				ContactParticipant(type = ParticipantType.SecondaryPerformer, hcpId = "hcp-secondaryPerformer"),
+				ContactParticipant(type = ParticipantType.PrimaryPerformer, hcpId = "hcp-primaryPerformer"),
+				ContactParticipant(type = ParticipantType.Participation, hcpId = "hcp-participation"),
+				ContactParticipant(type = ParticipantType.Translator, hcpId = "hcp-translator"),
+				ContactParticipant(type = ParticipantType.Emergency, hcpId = "hcp-emergency"),
+				ContactParticipant(type = ParticipantType.Location, hcpId = "hcp-location"),
+				ContactParticipant(type = ParticipantType.Recorder, hcpId = "hcp-recorder"),
+			)
+		}
+
+		"Deserialization should fail with invalid JSON value type" {
+			val json = """
+            {
+                "id": "entity6",
+                "participants": "invalid-string-value"
+            }
+			""".trimIndent()
+
+			shouldThrow<JsonMappingException> {
+				mapper.readValue<TestParticipantEntity>(json)
+			}
+		}
+
+		"Deserialization should fail with invalid JSON value type (number)" {
+			val json = """
+            {
+                "id": "entity7",
+                "participants": 12345
+            }
+			""".trimIndent()
+
+			shouldThrow<JsonMappingException> {
+				mapper.readValue<TestParticipantEntity>(json)
+			}
+		}
+	})
+

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/ContactDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/ContactDto.kt
@@ -13,6 +13,7 @@ import org.taktik.icure.services.external.rest.v1.dto.base.IdentifierDto
 import org.taktik.icure.services.external.rest.v1.dto.base.ParticipantTypeDto
 import org.taktik.icure.services.external.rest.v1.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.AddressDto
+import org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.DelegationDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.SecurityMetadataDto
@@ -56,9 +57,10 @@ data class ContactDto(
 		description = "Set of all sub-contacts recorded during the given contact. Sub-contacts are used to link services embedded inside this contact to healthcare elements, healthcare approaches and/or forms.",
 	) val subContacts: Set<SubContactDto> = emptySet(),
 	@param:Schema(description = "Set of all services provided to the patient during the contact.") val services: Set<ServiceDto> = emptySet(),
-	@param:Schema(
-		description = "The participants to the contact. The key is the type of participant, the value is the id of the participant data owner id",
-	) val participants: Map<ParticipantTypeDto, String> = emptyMap(),
+	@Deprecated("Use participantList", replaceWith = ReplaceWith("participantList"))
+	@param:Schema(description = "The participants to the contact. The key is the type of participant, the value is the id of the participant data owner id")
+	val participants: Map<ParticipantTypeDto, String> = emptyMap(),
+	val participantList: List<ContactParticipantDto> = emptyList(),
 	@get:Deprecated("Use responsible") val healthcarePartyId: String? = null, // Redundant... Should be responsible
 	@get:Deprecated("Use groupId") val modifiedContactId: String? = null,
 	override val secretForeignKeys: Set<String> = emptySet(),

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/base/ParticipantTypeDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/base/ParticipantTypeDto.kt
@@ -56,11 +56,17 @@ enum class ParticipantTypeDto {
 	@JsonProperty("secondaryPerformer")
 	SecondaryPerformer,
 
+	@JsonProperty("secondaryPerformerOrganization")
+	SecondaryPerformerOrganization,
+
 	/**
 	 * The principal or primary performer of the act.
 	 */
 	@JsonProperty("primaryPerformer")
 	PrimaryPerformer,
+
+	@JsonProperty("primaryPerformerOrganization")
+	PrimaryPerformerOrganization,
 
 	/**
 	 * Indicates that the target of the participation is involved in some manner in the act, but does not qualify how.
@@ -85,4 +91,10 @@ enum class ParticipantTypeDto {
 	 */
 	@JsonProperty("location")
 	Location,
+
+	@JsonProperty("recorder")
+	Recorder,
+
+	@JsonProperty("recorderOrganization")
+	RecorderOrganization,
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/base/ParticipantTypeDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/base/ParticipantTypeDto.kt
@@ -56,17 +56,11 @@ enum class ParticipantTypeDto {
 	@JsonProperty("secondaryPerformer")
 	SecondaryPerformer,
 
-	@JsonProperty("secondaryPerformerOrganization")
-	SecondaryPerformerOrganization,
-
 	/**
 	 * The principal or primary performer of the act.
 	 */
 	@JsonProperty("primaryPerformer")
 	PrimaryPerformer,
-
-	@JsonProperty("primaryPerformerOrganization")
-	PrimaryPerformerOrganization,
 
 	/**
 	 * Indicates that the target of the participation is involved in some manner in the act, but does not qualify how.
@@ -94,7 +88,4 @@ enum class ParticipantTypeDto {
 
 	@JsonProperty("recorder")
 	Recorder,
-
-	@JsonProperty("recorderOrganization")
-	RecorderOrganization,
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/ContactParticipantDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/ContactParticipantDto.kt
@@ -8,6 +8,5 @@ import org.taktik.icure.services.external.rest.v1.dto.base.ParticipantTypeDto
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ContactParticipantDto(
 	val type: ParticipantTypeDto,
-	val practitionerId: String? = null,
-	val organizationId: String? = null,
+	val hcpId: String,
 )

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/ContactParticipantDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/ContactParticipantDto.kt
@@ -8,5 +8,6 @@ import org.taktik.icure.services.external.rest.v1.dto.base.ParticipantTypeDto
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ContactParticipantDto(
 	val type: ParticipantTypeDto,
-	val referenceId: String
+	val practitionerId: String? = null,
+	val organizationId: String? = null,
 )

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/ContactParticipantDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/ContactParticipantDto.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.services.external.rest.v1.dto.embed
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import org.taktik.icure.services.external.rest.v1.dto.base.ParticipantTypeDto
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ContactParticipantDto(
+	val type: ParticipantTypeDto,
+	val referenceId: String
+)

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ContactDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ContactDto.kt
@@ -28,6 +28,7 @@ import org.taktik.icure.services.external.rest.v2.dto.base.ParticipantTypeDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.AddressDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.AnnotationDto
+import org.taktik.icure.services.external.rest.v2.dto.embed.ContactParticipantDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.DelegationDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
@@ -72,9 +73,10 @@ data class ContactDto(
 		description = "Set of all sub-contacts recorded during the given contact. Sub-contacts are used to link services embedded inside this contact to healthcare elements, healthcare approaches and/or forms.",
 	) val subContacts: Set<SubContactDto> = emptySet(),
 	@param:Schema(description = "Set of all services provided to the patient during the contact.") val services: Set<ServiceDto> = emptySet(),
-	@param:Schema(
-		description = "The participants to the contact. The key is the type of participant, the value is the id of the participant data owner id",
-	) val participants: Map<ParticipantTypeDto, String> = emptyMap(),
+	@param:Schema(description = "The participants to the contact. The key is the type of participant, the value is the id of the participant data owner id")
+	@Deprecated("Use participantList", replaceWith = ReplaceWith("participantList"))
+	val participants: Map<ParticipantTypeDto, String> = emptyMap(),
+	val participantList: List<ContactParticipantDto> = emptyList(),
 	@get:Deprecated("Use responsible") val healthcarePartyId: String? = null, // Redundant... Should be responsible
 	@get:Deprecated("Use groupId") val modifiedContactId: String? = null,
 	override val secretForeignKeys: Set<String> = emptySet(),

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/base/ParticipantTypeDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/base/ParticipantTypeDto.kt
@@ -56,11 +56,17 @@ enum class ParticipantTypeDto {
 	@JsonProperty("secondaryPerformer")
 	SecondaryPerformer,
 
+	@JsonProperty("secondaryPerformerOrganization")
+	SecondaryPerformerOrganization,
+
 	/**
 	 * The principal or primary performer of the act.
 	 */
 	@JsonProperty("primaryPerformer")
 	PrimaryPerformer,
+
+	@JsonProperty("primaryPerformerOrganization")
+	PrimaryPerformerOrganization,
 
 	/**
 	 * Indicates that the target of the participation is involved in some manner in the act, but does not qualify how.
@@ -85,4 +91,10 @@ enum class ParticipantTypeDto {
 	 */
 	@JsonProperty("location")
 	Location,
+
+	@JsonProperty("recorder")
+	Recorder,
+
+	@JsonProperty("recorderOrganization")
+	RecorderOrganization,
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/base/ParticipantTypeDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/base/ParticipantTypeDto.kt
@@ -56,17 +56,11 @@ enum class ParticipantTypeDto {
 	@JsonProperty("secondaryPerformer")
 	SecondaryPerformer,
 
-	@JsonProperty("secondaryPerformerOrganization")
-	SecondaryPerformerOrganization,
-
 	/**
 	 * The principal or primary performer of the act.
 	 */
 	@JsonProperty("primaryPerformer")
 	PrimaryPerformer,
-
-	@JsonProperty("primaryPerformerOrganization")
-	PrimaryPerformerOrganization,
 
 	/**
 	 * Indicates that the target of the participation is involved in some manner in the act, but does not qualify how.
@@ -94,7 +88,4 @@ enum class ParticipantTypeDto {
 
 	@JsonProperty("recorder")
 	Recorder,
-
-	@JsonProperty("recorderOrganization")
-	RecorderOrganization,
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ContactParticipantDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ContactParticipantDto.kt
@@ -8,6 +8,5 @@ import org.taktik.icure.services.external.rest.v2.dto.base.ParticipantTypeDto
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ContactParticipantDto(
 	val type: ParticipantTypeDto,
-	val practitionerId: String? = null,
-	val organizationId: String? = null,
+	val hcpId: String,
 )

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ContactParticipantDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ContactParticipantDto.kt
@@ -8,5 +8,6 @@ import org.taktik.icure.services.external.rest.v2.dto.base.ParticipantTypeDto
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ContactParticipantDto(
 	val type: ParticipantTypeDto,
-	val referenceId: String
+	val practitionerId: String? = null,
+	val organizationId: String? = null,
 )

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ContactParticipantDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ContactParticipantDto.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.services.external.rest.v2.dto.embed
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import org.taktik.icure.services.external.rest.v2.dto.base.ParticipantTypeDto
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ContactParticipantDto(
+	val type: ParticipantTypeDto,
+	val referenceId: String
+)

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ContactMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ContactMapper.kt
@@ -27,7 +27,7 @@ interface ContactMapper {
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
 		Mapping(target = "notes", ignore = true),
-		Mapping(target = "participants", expression = """kotlin((contactDto.participants.map { org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) })"""),
+		Mapping(target = "participants", expression = """kotlin((contactDto.participants.map { org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).distinct().map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) })"""),
 	)
 	fun map(contactDto: ContactDto): Contact
 
@@ -37,3 +37,8 @@ interface ContactMapper {
 	)
 	fun map(contact: Contact): ContactDto
 }
+
+fun toEntity(contactDto: ContactDto, contactMapper: ContactMapper): Contact = Contact(
+	id = contactDto.id,
+	participants = (contactDto.participants.map { org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).distinct().map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) }
+)

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ContactMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ContactMapper.kt
@@ -27,7 +27,13 @@ interface ContactMapper {
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
 		Mapping(target = "notes", ignore = true),
+		Mapping(target = "participants", expression = """kotlin((contactDto.participants.map { org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) })"""),
 	)
 	fun map(contactDto: ContactDto): Contact
+
+	@Mappings(
+		Mapping(target = "participants", expression = """kotlin(contact.participants.associate { (type, hcpId) -> org.taktik.icure.services.external.rest.v1.dto.base.ParticipantTypeDto.valueOf(type.name) to hcpId })"""),
+		Mapping(target = "participantList", expression = """kotlin(contact.participants.map { org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto(org.taktik.icure.services.external.rest.v1.dto.base.ParticipantTypeDto.valueOf(it.type.name), it.hcpId) })"""),
+	)
 	fun map(contact: Contact): ContactDto
 }

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ContactMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ContactMapper.kt
@@ -13,13 +13,13 @@ import org.taktik.icure.services.external.rest.v1.dto.ContactDto
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeStubMapper
 import org.taktik.icure.services.external.rest.v1.mapper.base.IdentifierMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.AddressMapper
-import org.taktik.icure.services.external.rest.v1.mapper.embed.AnnotationMapper
+import org.taktik.icure.services.external.rest.v1.mapper.embed.ContactParticipantMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.DelegationMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.SecurityMetadataMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.ServiceMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.SubContactMapper
 
-@Mapper(componentModel = "spring", uses = [IdentifierMapper::class, SubContactMapper::class, CodeStubMapper::class, DelegationMapper::class, ServiceMapper::class, SecurityMetadataMapper::class, AddressMapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper(componentModel = "spring", uses = [IdentifierMapper::class, SubContactMapper::class, CodeStubMapper::class, DelegationMapper::class, ServiceMapper::class, SecurityMetadataMapper::class, AddressMapper::class, ContactParticipantMapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 interface ContactMapper {
 	@Mappings(
 		Mapping(target = "attachments", ignore = true),

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/embed/ContactParticipantMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/embed/ContactParticipantMapper.kt
@@ -1,0 +1,13 @@
+package org.taktik.icure.services.external.rest.v1.mapper.embed
+
+import org.mapstruct.InjectionStrategy
+import org.mapstruct.Mapper
+import org.taktik.icure.entities.embed.ContactParticipant
+import org.taktik.icure.services.external.rest.v1.dto.embed.ContactParticipantDto
+
+@Mapper(componentModel = "spring", uses = [], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+interface ContactParticipantMapper {
+	fun map(participantDto: ContactParticipantDto): ContactParticipant
+
+	fun map(participant: ContactParticipant): ContactParticipantDto
+}

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ContactMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ContactMapper.kt
@@ -41,7 +41,13 @@ interface ContactV2Mapper {
 		Mapping(target = "revHistory", ignore = true),
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
+		Mapping(target = "participants", expression = """kotlin((contactDto.participants.map { org.taktik.icure.services.external.rest.v2.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) })"""),
 	)
 	fun map(contactDto: ContactDto): Contact
+
+	@Mappings(
+		Mapping(target = "participants", expression = """kotlin(contact.participants.associate { (type, hcpId) -> org.taktik.icure.services.external.rest.v2.dto.base.ParticipantTypeDto.valueOf(type.name) to hcpId })"""),
+		Mapping(target = "participantList", expression = """kotlin(contact.participants.map { org.taktik.icure.services.external.rest.v2.dto.embed.ContactParticipantDto(org.taktik.icure.services.external.rest.v2.dto.base.ParticipantTypeDto.valueOf(it.type.name), it.hcpId) })"""),
+	)
 	fun map(contact: Contact): ContactDto
 }

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ContactMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ContactMapper.kt
@@ -28,12 +28,13 @@ import org.taktik.icure.services.external.rest.v2.mapper.base.CodeStubV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.base.IdentifierV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.AddressV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.AnnotationV2Mapper
+import org.taktik.icure.services.external.rest.v2.mapper.embed.ContactParticipantV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.DelegationV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.SecurityMetadataV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.ServiceV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.SubContactV2Mapper
 
-@Mapper(componentModel = "spring", uses = [IdentifierV2Mapper::class, SubContactV2Mapper::class, CodeStubV2Mapper::class, DelegationV2Mapper::class, ServiceV2Mapper::class, SecurityMetadataV2Mapper::class, AnnotationV2Mapper::class, AddressV2Mapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper(componentModel = "spring", uses = [IdentifierV2Mapper::class, SubContactV2Mapper::class, CodeStubV2Mapper::class, DelegationV2Mapper::class, ServiceV2Mapper::class, SecurityMetadataV2Mapper::class, AnnotationV2Mapper::class, AddressV2Mapper::class, ContactParticipantV2Mapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 interface ContactV2Mapper {
 	@Mappings(
 		Mapping(target = "attachments", ignore = true),

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ContactMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ContactMapper.kt
@@ -41,7 +41,7 @@ interface ContactV2Mapper {
 		Mapping(target = "revHistory", ignore = true),
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
-		Mapping(target = "participants", expression = """kotlin((contactDto.participants.map { org.taktik.icure.services.external.rest.v2.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) })"""),
+		Mapping(target = "participants", expression = """kotlin((contactDto.participants.map { org.taktik.icure.services.external.rest.v2.dto.embed.ContactParticipantDto(it.key, it.value) } + contactDto.participantList).distinct().map { org.taktik.icure.entities.embed.ContactParticipant(org.taktik.icure.entities.base.ParticipantType.valueOf(it.type.name), it.hcpId) })"""),
 	)
 	fun map(contactDto: ContactDto): Contact
 

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/embed/ContactParticipantMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/embed/ContactParticipantMapper.kt
@@ -1,0 +1,13 @@
+package org.taktik.icure.services.external.rest.v2.mapper.embed
+
+import org.mapstruct.InjectionStrategy
+import org.mapstruct.Mapper
+import org.taktik.icure.entities.embed.ContactParticipant
+import org.taktik.icure.services.external.rest.v2.dto.embed.ContactParticipantDto
+
+@Mapper(componentModel = "spring", uses = [], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+interface ContactParticipantV2Mapper {
+	fun map(participantDto: ContactParticipantDto): ContactParticipant
+
+	fun map(participant: ContactParticipant): ContactParticipantDto
+}


### PR DESCRIPTION
Jira: [ICBE-537](https://icure.atlassian.net/browse/ICBE-537)

Using a map for participants was a bad idea since multiple participant could have the same type (callback contact could be the whole family).

This pull request introduces a new, more flexible way to represent contact participants by adding a `participantList` field to the `Contact` and `ContactDto` classes, deprecating the previous `participants` map. It also expands the set of participant types to include organization and recorder roles, and implements the necessary DTOs and mappers to support these changes in both v1 and v2 APIs.

These changes collectively modernize how participants are represented in contacts, making the model more extensible and future-proof.

[ICBE-537]: https://icure.atlassian.net/browse/ICBE-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ