### PR TITLE
Parent id filter for HCP requires no full read permission

### DIFF
--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/hcparty/HealthcarePartyByParentIdFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/hcparty/HealthcarePartyByParentIdFilter.kt
@@ -12,7 +12,7 @@ data class HealthcarePartyByParentIdFilter(
 	HealthcarePartyByParentIdFilter {
 
 	override val canBeUsedInWebsocket = true
-	override val requiresSecurityPrecondition: Boolean = true
+	override val requiresSecurityPrecondition: Boolean = false
 	override fun requestedDataOwnerIds(): Set<String> = emptySet()
 
 	override fun matches(item: HealthcareParty, searchKeyMatcher: (String, HasEncryptionMetadata) -> Boolean): Boolean = item.parentId == parentId


### PR DESCRIPTION
Jira: [ICBE-534](https://icure.atlassian.net/browse/ICBE-534)

Parent id is part of an HCP public information, therefore filter by parent id shouldn't require full read permission

[ICBE-534]: https://icure.atlassian.net/browse/ICBE-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ