### PR TITLE
Updated DTOs for conditional encoding

### DIFF
--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/AccessLogDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/AccessLogDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import io.swagger.v3.oas.annotations.media.Schema
@@ -34,7 +33,6 @@ import org.taktik.icure.utils.InstantDeserializer
 import org.taktik.icure.utils.InstantSerializer
 import java.time.Instant
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(description = """This entity represents Access Log.""")
 data class AccessLogDto(

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/AgendaDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/AgendaDto.kt
@@ -30,7 +30,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.ResourceGroupAllocat
 import org.taktik.icure.services.external.rest.v2.dto.embed.RightDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.UserAccessLevelDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AgendaDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ApplicationSettingsDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ApplicationSettingsDto.kt
@@ -19,7 +19,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEndOfLifeDto
@@ -30,7 +29,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ApplicationSettingsDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ArticleDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ArticleDto.kt
@@ -19,7 +19,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEndOfLifeDto
@@ -30,7 +29,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ArticleDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CalendarItemDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CalendarItemDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -32,7 +31,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.FlowItemDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class CalendarItemDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ClassificationDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ClassificationDto.kt
@@ -19,7 +19,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -31,7 +30,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ClassificationDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ClassificationTemplateDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ClassificationTemplateDto.kt
@@ -18,13 +18,11 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEndOfLifeDto
 import org.taktik.icure.services.external.rest.v2.dto.base.ICureDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ClassificationTemplateDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CodeDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CodeDto.kt
@@ -26,7 +26,6 @@ import org.taktik.icure.services.external.rest.v2.dto.base.CodeIdentificationDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.PeriodicityDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class CodeDto(
 	override val id: String, // id = type|code|version  => this must be unique
@@ -36,7 +35,7 @@ data class CodeDto(
 	override val type: String? = null, // ex: ICD (type + version + code combination must be unique) (or from tags -> CD-ITEM)
 	override val code: String? = null, // ex: I06.2 (or from tags -> healthcareelement). Local codes are encoded as LOCAL:SLLOCALFROMMYSOFT
 	override val version: String? = null, // ex: 10. Must be lexicographically searchable
-	val label: Map<String, String>? = null, // ex: {en: Rheumatic Aortic Stenosis, fr: Sténose rhumatoïde de l'Aorte}
+	@param:JsonInclude(JsonInclude.Include.NON_NULL) val label: Map<String, String>? = null, // ex: {en: Rheumatic Aortic Stenosis, fr: Sténose rhumatoïde de l'Aorte}
 	val author: String? = null,
 	val regions: Set<String> = emptySet(), // ex: be,fr
 	@Deprecated("This field is deprecated for the use with Cardinal SDK")

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ContactDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ContactDto.kt
@@ -37,7 +37,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.ServiceDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SubContactDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root-level object. It represents a contact. It is serialized in JSON and saved in the underlying icure-contact CouchDB database.

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DeviceDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DeviceDto.kt
@@ -32,7 +32,6 @@ import org.taktik.icure.services.external.rest.v2.dto.specializations.AesExchang
 import org.taktik.icure.services.external.rest.v2.dto.specializations.HexStringDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.SpkiHexStringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents a device. It is serialized in JSON and saved in the underlying icure-device CouchDB database.""",
@@ -69,7 +68,7 @@ data class DeviceDto(
 	override val privateKeyShamirPartitions: Map<String, HexStringDto> = emptyMap(), // Format is hcpId of key that has been partitioned : "threshold|partition in hex"
 	override val publicKey: SpkiHexStringDto? = null,
 	override val publicKeysForOaepWithSha256: Set<SpkiHexStringDto> = emptySet(),
-	override val cryptoActorProperties: Set<PropertyStubDto>? = null,
+	@param:JsonInclude(JsonInclude.Include.NON_NULL) override val cryptoActorProperties: Set<PropertyStubDto>? = null,
 ) : StoredDocumentDto,
 	ICureDocumentDto<String>,
 	NamedDto,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DocumentDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DocumentDto.kt
@@ -34,7 +34,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents a Document. It is serialized in JSON and saved in the underlying CouchDB database.""",

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/FormDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/FormDto.kt
@@ -22,7 +22,6 @@ package org.taktik.icure.services.external.rest.v2.dto
  */
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -33,7 +32,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class FormDto(
 	@param:Schema(description = "the Id of the form. We encourage using either a v4 UUID or a HL7 Id.") override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthElementDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthElementDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -36,7 +35,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.PlanOfActionDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents a healthcare element. It is serialized in JSON and saved in the underlying CouchDB database.""",

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthElementTemplateDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthElementTemplateDto.kt
@@ -26,7 +26,6 @@ import org.taktik.icure.services.external.rest.v2.dto.base.ICureDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.PlanOfActionTemplateDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class HealthElementTemplateDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthcarePartyDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/HealthcarePartyDto.kt
@@ -42,7 +42,6 @@ import org.taktik.icure.services.external.rest.v2.dto.specializations.AesExchang
 import org.taktik.icure.services.external.rest.v2.dto.specializations.HexStringDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.SpkiHexStringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents a healthcare party. It is serialized in JSON and saved in the underlying icure-healthdata CouchDB database.""",
@@ -116,6 +115,7 @@ data class HealthcarePartyDto(
 	val sendFormats: Map<TelecomTypeDto, String> = emptyMap(),
 	@param:Schema(description = "Text notes.") val notes: String? = null,
 	@param:Schema(description = "List of financial information (Bank, bank account).") val financialInstitutionInformation: List<FinancialInstitutionInformationDto> = emptyList(),
+	@param:JsonInclude(JsonInclude.Include.NON_NULL)
 	@param:Schema(description = "A description of the HCP, meant for the public and in multiple languages.", defaultValue = "emptyMap()") val descr: Map<String, String>? = emptyMap(),
 	// Medical houses
 	@Deprecated("This field is deprecated for the use with Cardinal SDK")
@@ -138,7 +138,7 @@ data class HealthcarePartyDto(
 	override val properties: Set<PropertyStubDto> = emptySet(),
 	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val public: Boolean = false,
 	@param:JsonInclude(JsonInclude.Include.NON_DEFAULT) val publicProperties: Set<PropertyStubDto>? = null,
-	override val cryptoActorProperties: Set<PropertyStubDto>? = null,
+	@param:JsonInclude(JsonInclude.Include.NON_NULL) override val cryptoActorProperties: Set<PropertyStubDto>? = null,
 	override val hcPartyKeys: Map<String, List<HexStringDto>> = emptyMap(),
 	override val aesExchangeKeys: Map<AesExchangeKeyEntryKeyStringDto, Map<String, Map<AesExchangeKeyEncryptionKeypairIdentifierDto, HexStringDto>>> = emptyMap(),
 	override val transferKeys: Map<AesExchangeKeyEncryptionKeypairIdentifierDto, Map<AesExchangeKeyEncryptionKeypairIdentifierDto, HexStringDto>> = emptyMap(),

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/InvoiceDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/InvoiceDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -37,7 +36,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.PaymentTypeDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents an Invoice. It is serialized in JSON and saved in the underlying iCure CouchDB database.""",

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/KeywordDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/KeywordDto.kt
@@ -25,7 +25,6 @@ import org.taktik.icure.services.external.rest.v2.dto.base.ICureDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.KeywordSubwordDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class KeywordDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/MessageDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/MessageDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -32,7 +31,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 import org.taktik.icure.utils.DynamicInitializer
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents a Message. It is serialized in JSON and saved in the underlying CouchDB database.""",

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/PatientDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/PatientDto.kt
@@ -51,7 +51,6 @@ import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64Stri
 import org.taktik.icure.services.external.rest.v2.dto.specializations.HexStringDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.SpkiHexStringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents a patient It is serialized in JSON and saved in the underlying icure-patient CouchDB database.""",
@@ -171,7 +170,7 @@ data class PatientDto(
 	override val encryptionKeys: Map<String, Set<DelegationDto>> = emptyMap(),
 	override val encryptedSelf: Base64StringDto? = null,
 	override val securityMetadata: SecurityMetadataDto? = null,
-	@AlwaysDecrypted override val cryptoActorProperties: Set<PropertyStubDto>? = null,
+	@AlwaysDecrypted @param:JsonInclude(JsonInclude.Include.NON_NULL) override val cryptoActorProperties: Set<PropertyStubDto>? = null,
 	@Deprecated("This field is deprecated for the use with Cardinal SDK")
 	override val medicalLocationId: String? = null,
 	@Deprecated("Do not use") val nonDuplicateIds: Set<String> = emptySet(),

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/PropertyStubDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/PropertyStubDto.kt
@@ -18,12 +18,10 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.TypedValueDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PropertyStubDto(
 	val id: String? = null,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ReceiptDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ReceiptDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.base.ICureDocumentDto
@@ -29,7 +28,6 @@ import org.taktik.icure.services.external.rest.v2.dto.embed.ReceiptBlobTypeDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64StringDto
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ReceiptDto(
 	override val id: String,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/TopicDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/TopicDto.kt
@@ -18,7 +18,6 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.base.ICureDocumentDto
@@ -34,7 +33,6 @@ enum class TopicRoleDto {
 	OWNER,
 }
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TopicDto(
 	override val id: String,


### PR DESCRIPTION
Jira: [ICBE-408](https://icure.atlassian.net/browse/ICBE-408)

Scope of the PR:
we want to avoid generating fields that are deprecated on the SDK data model. However this will not work as we use strict deserialization in the SDK, and the current serialization method still puts empty collections because of `JsonInclude.Include.NON_NULL`.

The proposed solution is:
- Extend the functionality of the existing custom Spring encoder to accept 2 mappers: one with `setSerializationInclusion(JsonInclude.Include.NON_NULL)` and the other with `setSerializationInclusion(JsonInclude.Include.NON_EMPTY)`. The latter wil be used only if the header `Cardinal-Json-Mode` with value `NOT_EMPTY` is present in the request. This way, we can leverage the non empty serializaztion strategy for the SDK but still allow the previous behavior for the old typescript SDK.

- Remove the `@JsonInclude(JsonInclude.Include.NON_NULL)` annotation in DTO classes that have deprecated fields. This has no impact as the current mapper already has the `JsonInclude.Include.NON_NULL` default behaviour.

- Add the `@param:JsonInclude(JsonInclude.Include.NON_NULL)` annotation to fields with nullable collection types.

[ICBE-408]: https://icure.atlassian.net/browse/ICBE-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ