### PR TITLE
POC filter fields when serializing DTOs

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/config/SharedWebConfig.kt
+++ b/core/src/main/kotlin/org/taktik/icure/config/SharedWebConfig.kt
@@ -6,6 +6,9 @@ package org.taktik.icure.config
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ser.FilterProvider
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.context.annotation.Bean
@@ -66,6 +69,36 @@ abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
 			.allowedMethods("*")
 			.allowedHeaders("*")
 	}
+
+	private val legacyJacksonFilter: FilterProvider = SimpleFilterProvider().addFilter(
+		"userFilter",
+		SimpleBeanPropertyFilter.serializeAll()
+	)
+
+	protected val legacyObjectMapper: ObjectMapper =
+		ObjectMapper().registerModule(
+			KotlinModule.Builder()
+				.configure(KotlinFeature.NullIsSameAsDefault, true)
+				.build()
+		).apply {
+			setSerializationInclusion(JsonInclude.Include.NON_NULL)
+			setFilterProvider(legacyJacksonFilter)
+		}
+
+	private val cardinalJacksonFilter: FilterProvider = SimpleFilterProvider().addFilter(
+		"userFilter",
+		SimpleBeanPropertyFilter.serializeAllExcept("createdDate")
+	)
+
+	protected val cardinalObjectMapper: ObjectMapper =
+		ObjectMapper().registerModule(
+			KotlinModule.Builder()
+				.configure(KotlinFeature.NullIsSameAsDefault, true)
+				.build()
+		).apply {
+			setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+			setFilterProvider(cardinalJacksonFilter)
+		}
 
 	abstract fun getJackson2JsonEncoder(): Encoder<Any>
 

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/UserDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/UserDto.kt
@@ -17,6 +17,7 @@
  */
 package org.taktik.icure.services.external.rest.v2.dto
 
+import com.fasterxml.jackson.annotation.JsonFilter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -36,11 +37,11 @@ import org.taktik.icure.utils.InstantSerializer
 import java.io.Serializable
 import java.time.Instant
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Schema(
 	description = """This entity is a root level object. It represents an user that can log in to the iCure platform. It is serialized in JSON and saved in the underlying icure-base CouchDB database.""",
 )
+@JsonFilter("userFilter")
 data class UserDto(
 	@param:Schema(description = "the Id of the user. We encourage using either a v4 UUID or a HL7 Id.") override val id: String,
 	@param:Schema(description = "the revision of the user in the database, used for conflict management / optimistic locking.") override val rev: String? = null,


### PR DESCRIPTION
Jira: [ICBE-375](https://icure.atlassian.net/browse/ICBE-375)

Not needed right now but a reminder in case we need it for the future.

It is possible to annotate a class with the `@JsonFilter` annotation and then filter out its fields when serializing using a configuration on the mapper.

[ICBE-375]: https://icure.atlassian.net/browse/ICBE-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ