### PR TITLE
Deprecate FormTemplate listBySpecialty and add FormTemplateBySpecialtyFilter with matchBy endpoint

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/FormTemplateDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/FormTemplateDAOImpl.kt
@@ -20,6 +20,7 @@ import org.taktik.couchdb.annotation.View
 import org.taktik.couchdb.dao.DesignDocumentProvider
 import org.taktik.couchdb.entity.ComplexKey
 import org.taktik.couchdb.id.IDGenerator
+import org.taktik.couchdb.queryView
 import org.taktik.couchdb.queryViewIncludeDocsNoValue
 import org.taktik.icure.asyncdao.CouchDbDispatcher
 import org.taktik.icure.asyncdao.FormTemplateDAO
@@ -121,6 +122,21 @@ internal class FormTemplateDAOImpl(
 			} else {
 				formTemplates
 			},
+		)
+	}
+
+	override fun listFormTemplateIdsBySpecialty(datastoreInformation: IDatastoreInformation, specialtyCode: String) = flow {
+		val client = couchDbDispatcher.getClient(datastoreInformation)
+
+		val from = ComplexKey.of(specialtyCode, null)
+		val to = ComplexKey.of(specialtyCode, ComplexKey.emptyObject())
+		emitAll(
+			client.queryView<Array<String>, String>(
+				createQuery(
+					datastoreInformation,
+					"by_specialty_code_and_guid",
+				).startKey(from).endKey(to).includeDocs(false),
+			).map { it.id },
 		)
 	}
 

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/FormTemplateLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/FormTemplateLogicImpl.kt
@@ -46,6 +46,7 @@ class FormTemplateLogicImpl(
 			}.collect(this)
 	}
 
+	@Suppress("DEPRECATION")
 	override fun getFormTemplatesBySpecialty(
 		specialityCode: String,
 		loadLayout: Boolean,

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/formtemplate/FormTemplateBySpecialtyFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/formtemplate/FormTemplateBySpecialtyFilter.kt
@@ -1,0 +1,26 @@
+package org.taktik.icure.asynclogic.impl.filter.formtemplate
+
+import kotlinx.coroutines.flow.Flow
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import org.taktik.icure.asyncdao.FormTemplateDAO
+import org.taktik.icure.asynclogic.impl.filter.Filter
+import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.datastore.IDatastoreInformation
+import org.taktik.icure.domain.filter.formtemplate.FormTemplateBySpecialtyFilter
+import org.taktik.icure.entities.FormTemplate
+
+@Service
+@Profile("app")
+class FormTemplateBySpecialtyFilter(
+	private val formTemplateDAO: FormTemplateDAO,
+) : Filter<String, FormTemplate, FormTemplateBySpecialtyFilter> {
+	override fun resolve(
+		filter: FormTemplateBySpecialtyFilter,
+		context: Filters,
+		datastoreInformation: IDatastoreInformation,
+	): Flow<String> = formTemplateDAO.listFormTemplateIdsBySpecialty(
+		datastoreInformation = datastoreInformation,
+		specialtyCode = filter.specialtyCode,
+	)
+}

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/FormController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/FormController.kt
@@ -376,6 +376,8 @@ class  FormController(
 		)
 	}.injectReactorContext()
 
+	@Suppress("DEPRECATION")
+	@Deprecated("Use matchFormTemplatesBy with a FormTemplateBySpecialtyFilter instead")
 	@Operation(summary = "Gets all form templates")
 	@GetMapping("/template/bySpecialty/{specialityCode}")
 	fun listFormTemplatesBySpeciality(
@@ -597,6 +599,15 @@ class  FormController(
 		@RequestBody filter: AbstractFilterDto<FormDto>,
 	): Flux<String> = formService
 		.matchFormsBy(
+			filter = filterV2Mapper.tryMap(filter).orThrow(),
+		).injectReactorContext()
+
+	@Operation(summary = "Get the ids of the FormTemplates matching the provided filter.")
+	@PostMapping("/template/match", produces = [APPLICATION_JSON_VALUE])
+	fun matchFormTemplatesBy(
+		@RequestBody filter: AbstractFilterDto<FormTemplateDto>,
+	): Flux<String> = formTemplateService
+		.matchFormTemplatesBy(
 			filter = filterV2Mapper.tryMap(filter).orThrow(),
 		).injectReactorContext()
 }

--- a/dao/src/main/kotlin/org/taktik/icure/asyncdao/FormTemplateDAO.kt
+++ b/dao/src/main/kotlin/org/taktik/icure/asyncdao/FormTemplateDAO.kt
@@ -16,4 +16,6 @@ interface FormTemplateDAO :
 	fun listFormsByGuid(datastoreInformation: IDatastoreInformation, guid: String, loadLayout: Boolean): Flow<FormTemplate>
 
 	fun listFormsBySpecialtyAndGuid(datastoreInformation: IDatastoreInformation, specialityCode: String, guid: String?, loadLayout: Boolean): Flow<FormTemplate>
+
+	fun listFormTemplateIdsBySpecialty(datastoreInformation: IDatastoreInformation, specialtyCode: String): Flow<String>
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/formtemplate/FormTemplateBySpecialtyFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/formtemplate/FormTemplateBySpecialtyFilter.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.domain.filter.formtemplate
+
+import org.taktik.icure.domain.filter.Filter
+import org.taktik.icure.entities.FormTemplate
+
+/**
+ * Retrieves all the [FormTemplate]s where [FormTemplate.specialty] code is equal to [specialtyCode].
+ * This filter requires a special permission to be used.
+ */
+interface FormTemplateBySpecialtyFilter : Filter<String, FormTemplate> {
+	val specialtyCode: String
+}

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/formtemplate/FormTemplateBySpecialtyFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/formtemplate/FormTemplateBySpecialtyFilter.kt
@@ -1,0 +1,20 @@
+package org.taktik.icure.domain.filter.impl.formtemplate
+
+import org.taktik.icure.domain.filter.AbstractFilter
+import org.taktik.icure.domain.filter.formtemplate.FormTemplateBySpecialtyFilter
+import org.taktik.icure.entities.FormTemplate
+import org.taktik.icure.entities.base.HasEncryptionMetadata
+
+data class FormTemplateBySpecialtyFilter(
+	override val specialtyCode: String,
+	override val desc: String? = null,
+) : AbstractFilter<FormTemplate>,
+	FormTemplateBySpecialtyFilter {
+
+	override val canBeUsedInWebsocket = true
+	override val requiresSecurityPrecondition: Boolean = true
+	override fun requestedDataOwnerIds(): Set<String> = emptySet()
+
+	override fun matches(item: FormTemplate, searchKeyMatcher: (String, HasEncryptionMetadata) -> Boolean): Boolean =
+		item.specialty?.code == specialtyCode
+}

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/formtemplate/FormTemplateBySpecialtyFilter.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/formtemplate/FormTemplateBySpecialtyFilter.kt
@@ -1,0 +1,18 @@
+package org.taktik.icure.services.external.rest.v2.dto.filter.formtemplate
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.taktik.icure.handlers.JsonPolymorphismRoot
+import org.taktik.icure.services.external.rest.v2.dto.FormTemplateDto
+import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
+
+@JsonPolymorphismRoot(AbstractFilterDto::class)
+@JsonDeserialize(using = JsonDeserializer.None::class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class FormTemplateBySpecialtyFilter(
+	val specialtyCode: String,
+	override val desc: String? = null,
+) : AbstractFilterDto<FormTemplateDto>

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/FormTemplateLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/FormTemplateLogic.kt
@@ -12,6 +12,7 @@ interface FormTemplateLogic : EntityPersister<FormTemplate> {
 
 	@Deprecated("This method has unintuitive behaviour, read FormTemplateService.getFormTemplatesByGuid doc for more info")
 	fun getFormTemplatesByGuid(userId: String, specialityCode: String, formTemplateGuid: String): Flow<FormTemplate>
+	@Deprecated("Use matchEntitiesBy with a FormTemplateBySpecialtyFilter instead")
 	fun getFormTemplatesBySpecialty(specialityCode: String, loadLayout: Boolean): Flow<FormTemplate>
 	fun getFormTemplatesByUser(userId: String, loadLayout: Boolean): Flow<FormTemplate>
 }

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
@@ -35,6 +35,7 @@ import org.taktik.icure.entities.Contact
 import org.taktik.icure.entities.Device
 import org.taktik.icure.entities.Document
 import org.taktik.icure.entities.Form
+import org.taktik.icure.entities.FormTemplate
 import org.taktik.icure.entities.HealthElement
 import org.taktik.icure.entities.HealthcareParty
 import org.taktik.icure.entities.Insurance
@@ -57,6 +58,7 @@ import org.taktik.icure.services.external.rest.v2.dto.ContactDto
 import org.taktik.icure.services.external.rest.v2.dto.DeviceDto
 import org.taktik.icure.services.external.rest.v2.dto.DocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.FormDto
+import org.taktik.icure.services.external.rest.v2.dto.FormTemplateDto
 import org.taktik.icure.services.external.rest.v2.dto.HealthElementDto
 import org.taktik.icure.services.external.rest.v2.dto.HealthcarePartyDto
 import org.taktik.icure.services.external.rest.v2.dto.InsuranceDto
@@ -120,6 +122,7 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.form.FormByDataOwne
 import org.taktik.icure.services.external.rest.v2.dto.filter.form.FormByDataOwnerPatientOpeningDateFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.form.FormByLogicalUuidFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.form.FormByUniqueUuidFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.formtemplate.FormTemplateBySpecialtyFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.hcparty.AllHealthcarePartiesFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.hcparty.HealthcarePartyByIdentifiersFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.hcparty.HealthcarePartyByIdsFilter
@@ -352,6 +355,14 @@ abstract class FilterV2Mapper {
 		is FormByDataOwnerParentIdFilter -> map(filterDto)
 		is FormByLogicalUuidFilter -> map(filterDto)
 		is FormByUniqueUuidFilter -> map(filterDto)
+		else -> mapGeneralFilterToDomain(filterDto) { tryMap(it) }
+	}
+
+	abstract fun map(filterDto: FormTemplateBySpecialtyFilter): org.taktik.icure.domain.filter.impl.formtemplate.FormTemplateBySpecialtyFilter
+
+	@JvmName("tryMapFormTemplateFilter")
+	fun tryMap(filterDto: AbstractFilterDto<FormTemplateDto>): AbstractFilter<FormTemplate>? = when (filterDto) {
+		is FormTemplateBySpecialtyFilter -> map(filterDto)
 		else -> mapGeneralFilterToDomain(filterDto) { tryMap(it) }
 	}
 

--- a/service/src/main/kotlin/org/taktik/icure/asyncservice/FormTemplateService.kt
+++ b/service/src/main/kotlin/org/taktik/icure/asyncservice/FormTemplateService.kt
@@ -7,6 +7,7 @@ package org.taktik.icure.asyncservice
 import kotlinx.coroutines.flow.Flow
 import org.taktik.couchdb.DocIdentifier
 import org.taktik.couchdb.entity.IdAndRev
+import org.taktik.icure.domain.filter.AbstractFilter
 import org.taktik.icure.entities.FormTemplate
 
 interface FormTemplateService {
@@ -27,8 +28,10 @@ interface FormTemplateService {
 	 */
 	@Deprecated("This method has unintuitive behaviour, read FormTemplateService.getFormTemplatesByGuid doc for more info")
 	fun getFormTemplatesByGuid(userId: String, specialityCode: String, formTemplateGuid: String): Flow<FormTemplate>
+	@Deprecated("Use matchFormTemplatesBy with a FormTemplateBySpecialtyFilter instead")
 	fun getFormTemplatesBySpecialty(specialityCode: String, loadLayout: Boolean): Flow<FormTemplate>
 	fun getFormTemplatesByUser(userId: String, loadLayout: Boolean): Flow<FormTemplate>
+	fun matchFormTemplatesBy(filter: AbstractFilter<FormTemplate>): Flow<String>
 
 	/**
 	 * Deletes [FormTemplate]s in batch.


### PR DESCRIPTION
Jira: [ICBE-458](https://icure.atlassian.net/browse/ICBE-458)

Replace the direct listFormTemplatesBySpecialty methods with the standard filter/matchBy pattern used across the codebase for all other entity types.

New filter infrastructure:
- Domain filter interface and impl (FormTemplateBySpecialtyFilter)
- DTO filter for JSON deserialization
- Filter logic resolver calling the new DAO ID-only query
- DAO method listFormTemplateIdsBySpecialty using existing by_specialty_code_and_guid view
- FilterV2Mapper registration for FormTemplate filters
- New POST /template/match endpoint in v2 FormController
- Service interface matchFormTemplatesBy method

Deprecations:
- FormTemplateLogic.getFormTemplatesBySpecialty
- FormTemplateService.getFormTemplatesBySpecialty
- FormController.listFormTemplatesBySpeciality (v2)
- FormController.findFormTemplatesBySpeciality (v1)

[ICBE-458]: https://icure.atlassian.net/browse/ICBE-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ