### PR TITLE
Bypassed hash check in doCreateToken

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/UserLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/UserLogicImpl.kt
@@ -34,9 +34,9 @@ import org.taktik.icure.entities.User
 import org.taktik.icure.entities.base.PropertyStub
 import org.taktik.icure.entities.security.AuthenticationToken
 import org.taktik.icure.exceptions.ConflictRequestException
-import org.taktik.icure.exceptions.NonRespectedUnicityException
 import org.taktik.icure.exceptions.DuplicateUserException
 import org.taktik.icure.exceptions.DuplicateUserException.UniqueFieldType
+import org.taktik.icure.exceptions.NonRespectedUnicityException
 import org.taktik.icure.exceptions.NotFoundRequestException
 import org.taktik.icure.pagination.limitIncludingKey
 import org.taktik.icure.pagination.toPaginatedFlow
@@ -412,7 +412,7 @@ open class UserLogicImpl(
 							email = user.email?.takeIf { it.isNotBlank() },
 							mobilePhone = user.mobilePhone?.takeIf { it.isNotBlank() },
 							applicationTokens = emptyMap(),
-						).hashPasswordAndTokens(secretValidator::encodeAndValidateSecrets),
+						).hashPasswordAndTokens(secretValidator::encodeAndValidateSecretsIfNotHashed),
 					isCreate = user.rev == null,
 				)
 			}.takeIf { it.isNotEmpty() }
@@ -538,9 +538,9 @@ open class UserLogicImpl(
 						(
 							key to
 								AuthenticationToken(
-									secretValidator.encodeAndValidateSecrets(
-										authenticationToken,
-										if (tokenValidityWithinBounds in 1..AuthenticationToken.MAX_SHORT_LIVING_TOKEN_VALIDITY) {
+									secretValidator.encodeAndValidateSecret(
+										secret = authenticationToken,
+										secretType = if (tokenValidityWithinBounds in 1..AuthenticationToken.MAX_SHORT_LIVING_TOKEN_VALIDITY) {
 											SecretType.SHORT_TOKEN
 										} else {
 											SecretType.LONG_TOKEN

--- a/domain/src/main/kotlin/org/taktik/icure/security/credentials/BaseSecretValidator.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/security/credentials/BaseSecretValidator.kt
@@ -11,15 +11,22 @@ class BaseSecretValidator(
 	private val passwordEncoder: PasswordEncoder,
 	private val authenticationProperties: AuthenticationProperties,
 ) : SecretValidator {
-	override fun encodeAndValidateSecrets(
+	override fun encodeAndValidateSecretsIfNotHashed(
 		secretOrHash: String,
 		secretType: SecretType,
 	): String = if (!secretOrHash.matches(SecretValidator.hashedPasswordRegex)) {
-		if (secretType == SecretType.PASSWORD && secretOrHash.length < authenticationProperties.recommendedPasswordLength) {
-			throw IllegalArgumentException("Your password is too short. It should be at least ${authenticationProperties.recommendedPasswordLength} characters long.")
-		}
-		passwordEncoder.encode(secretOrHash)
+		encodeAndValidateSecret(secret = secretOrHash, secretType = secretType)
 	} else {
 		secretOrHash
+	}
+
+	override fun encodeAndValidateSecret(
+		secret: String,
+		secretType: SecretType,
+	): String {
+		if (secretType == SecretType.PASSWORD && secret.length < authenticationProperties.recommendedPasswordLength) {
+			throw IllegalArgumentException("Your password is too short. It should be at least ${authenticationProperties.recommendedPasswordLength} characters long.")
+		}
+		return passwordEncoder.encode(secret)
 	}
 }

--- a/domain/src/main/kotlin/org/taktik/icure/security/credentials/SecretValidator.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/security/credentials/SecretValidator.kt
@@ -10,7 +10,7 @@ interface SecretValidator {
 	}
 
 	/**
-	 * This method receives a secret or the hash of a secret an the [SecretType] of the secret.
+	 * This method receives a secret or the hash of a secret and the [SecretType] of the secret.
 	 * If the secret is a hash, then it returns it directly. Otherwise, it verifies it according to criteria that
 	 * are based on the [SecretType] and on the concrete implementation.
 	 * If the secret does not meet the security criteria, then an [IllegalArgumentException] is thrown, otherwise the
@@ -22,5 +22,17 @@ interface SecretValidator {
 	 * @throws IllegalArgumentException if the secret is not hashed and does not meet the security criteria defined by
 	 * the function.
 	 */
-	fun encodeAndValidateSecrets(secretOrHash: String, secretType: SecretType): String
+	fun encodeAndValidateSecretsIfNotHashed(secretOrHash: String, secretType: SecretType): String
+
+	/**
+	 * This method hashes a secret applying the same checks as in [encodeAndValidateSecretsIfNotHashed], but without
+	 * checking if [secret] is already hashed.
+	 *
+	 * @param secret a non-hashed secret (token, password, or other).
+	 * @param secretType the [SecretType] of the secret.
+	 * @return the hashed secret.
+	 * @throws IllegalArgumentException if the secret is not hashed and does not meet the security criteria defined by
+	 * the function.
+	 */
+	fun encodeAndValidateSecret(secret: String, secretType: SecretType): String
 }


### PR DESCRIPTION
Jira: [ICBE-372](https://icure.atlassian.net/browse/ICBE-372)

## Scope of the PR
If a user decides to specify the value of the token to create and uses, for example, a UUID without dashes, then it will be interpreted as a hash and not hashed in the db. 

The legacy behaviour is kept on modifyUser.

[ICBE-372]: https://icure.atlassian.net/browse/ICBE-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ