### PR TITLE
Add exact code/tag service filters with date support

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
@@ -1389,7 +1389,7 @@ class ContactDAOImpl(
 		}
 		if (endValueDate != null) {
 			val parsed = FuzzyDates.getLocalDateTimeWithPrecision(endValueDate, false)?.first
-			require(parsed != null) { "startValueDate must be a valid fuzzy date time if provided" }
+			require(parsed != null) { "endValueDate must be a valid fuzzy date time if provided" }
 		}
 		val client = couchDbDispatcher.getClient(datastoreInformation)
 		val keys = searchKeys.flatMap { dataOwnerSearchKey ->

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
@@ -1093,16 +1093,14 @@ class ContactDAOImpl(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
 		patientSecretForeignKeys: Set<String>,
-		tagType: String,
-		tagCodes: Collection<String>,
+		tagTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerPatientTagOrCodeExact(
 		datastoreInformation,
 		searchKeys,
 		patientSecretForeignKeys,
-		tagType,
-		tagCodes,
+		tagTypesAndCodes,
 		startValueDate,
 		endValueDate,
 		"service_by_data_owner_patient_tag_prefix",
@@ -1112,16 +1110,14 @@ class ContactDAOImpl(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
 		patientSecretForeignKeys: Set<String>,
-		codeType: String,
-		codeCodes: Collection<String>,
+		codeTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerPatientTagOrCodeExact(
 		datastoreInformation,
 		searchKeys,
 		patientSecretForeignKeys,
-		codeType,
-		codeCodes,
+		codeTypesAndCodes,
 		startValueDate,
 		endValueDate,
 		"service_by_data_owner_patient_code_prefix",
@@ -1131,8 +1127,7 @@ class ContactDAOImpl(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
 		patientSecretForeignKeys: Set<String>,
-		type: String,
-		codes: Collection<String>,
+		typesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 		view: String,
@@ -1140,8 +1135,10 @@ class ContactDAOImpl(
 		val client = couchDbDispatcher.getClient(datastoreInformation)
 		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
 			patientSecretForeignKeys.flatMap { patientSecretForeignKey ->
-				codes.map { code ->
-					ComplexKey.of(dataOwnerSearchKey, patientSecretForeignKey, type, code)
+				typesAndCodes.flatMap { (type, codes) ->
+					codes.map { code ->
+						ComplexKey.of(dataOwnerSearchKey, patientSecretForeignKey, type, code)
+					}
 				}
 			}
 		}
@@ -1237,15 +1234,13 @@ class ContactDAOImpl(
 	override fun listServiceIdsByDataOwnerTagCodes(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
-		tagType: String,
-		tagCodes: Collection<String>,
+		tagTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerTagOrCodeExact(
 		datastoreInformation,
 		searchKeys,
-		tagType,
-		tagCodes,
+		tagTypesAndCodes,
 		startValueDate,
 		endValueDate,
 		"service_by_data_owner_tag_prefix",
@@ -1254,15 +1249,13 @@ class ContactDAOImpl(
 	override fun listServiceIdsByDataOwnerCodeCodes(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
-		codeType: String,
-		codeCodes: Collection<String>,
+		codeTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerTagOrCodeExact(
 		datastoreInformation,
 		searchKeys,
-		codeType,
-		codeCodes,
+		codeTypesAndCodes,
 		startValueDate,
 		endValueDate,
 		"service_by_data_owner_code_prefix",
@@ -1271,16 +1264,17 @@ class ContactDAOImpl(
 	private fun listServiceIdsByDataOwnerTagOrCodeExact(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
-		type: String,
-		codes: Collection<String>,
+		typesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 		view: String,
 	): Flow<String> = flow {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
 		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
-			codes.map { code ->
-				ComplexKey.of(dataOwnerSearchKey, type, code)
+			typesAndCodes.flatMap { (type, codes) ->
+				codes.map { code ->
+					ComplexKey.of(dataOwnerSearchKey, type, code)
+				}
 			}
 		}
 		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
@@ -1345,8 +1339,7 @@ class ContactDAOImpl(
 		searchKeys: Set<String>,
 		year: Int?,
 		month: Int?,
-		tagType: String,
-		tagCodes: Collection<String>,
+		tagTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerValueDateMonthTagOrCodeExact(
@@ -1354,8 +1347,7 @@ class ContactDAOImpl(
 		searchKeys,
 		year,
 		month,
-		tagType,
-		tagCodes,
+		tagTypesAndCodes,
 		startValueDate,
 		endValueDate,
 		"service_by_data_owner_month_tag_prefix",
@@ -1366,8 +1358,7 @@ class ContactDAOImpl(
 		searchKeys: Set<String>,
 		year: Int?,
 		month: Int?,
-		codeType: String,
-		codeCodes: Collection<String>,
+		codeTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerValueDateMonthTagOrCodeExact(
@@ -1375,8 +1366,7 @@ class ContactDAOImpl(
 		searchKeys,
 		year,
 		month,
-		codeType,
-		codeCodes,
+		codeTypesAndCodes,
 		startValueDate,
 		endValueDate,
 		"service_by_data_owner_month_code_prefix",
@@ -1387,8 +1377,7 @@ class ContactDAOImpl(
 		searchKeys: Set<String>,
 		year: Int?,
 		month: Int?,
-		type: String,
-		codes: Collection<String>,
+		typesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 		view: String,
@@ -1404,8 +1393,10 @@ class ContactDAOImpl(
 		}
 		val client = couchDbDispatcher.getClient(datastoreInformation)
 		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
-			codes.map { code ->
-				ComplexKey.of(year, month, dataOwnerSearchKey, type, code)
+			typesAndCodes.flatMap { (type, codes) ->
+				codes.map { code ->
+					ComplexKey.of(year, month, dataOwnerSearchKey, type, code)
+				}
 			}
 		}
 		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
@@ -1089,18 +1089,91 @@ class ContactDAOImpl(
 		))
 	}
 
+	override fun listServiceIdsByDataOwnerPatientTagCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		patientSecretForeignKeys: Set<String>,
+		tagType: String,
+		tagCodes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): Flow<String> = listServiceIdsByDataOwnerPatientTagOrCodeExact(
+		datastoreInformation,
+		searchKeys,
+		patientSecretForeignKeys,
+		tagType,
+		tagCodes,
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_patient_tag_prefix",
+	)
+
+	override fun listServiceIdsByDataOwnerPatientCodeCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		patientSecretForeignKeys: Set<String>,
+		codeType: String,
+		codeCodes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): Flow<String> = listServiceIdsByDataOwnerPatientTagOrCodeExact(
+		datastoreInformation,
+		searchKeys,
+		patientSecretForeignKeys,
+		codeType,
+		codeCodes,
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_patient_code_prefix",
+	)
+
+	private fun listServiceIdsByDataOwnerPatientTagOrCodeExact(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		patientSecretForeignKeys: Set<String>,
+		type: String,
+		codes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+		view: String,
+	): Flow<String> = flow {
+		val client = couchDbDispatcher.getClient(datastoreInformation)
+		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
+			patientSecretForeignKeys.flatMap { patientSecretForeignKey ->
+				codes.map { code ->
+					ComplexKey.of(dataOwnerSearchKey, patientSecretForeignKey, type, code)
+				}
+			}
+		}
+		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
+			.keys(keys)
+			.includeDocs(false)
+		val results = client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
+			if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+		}.let { f ->
+			if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+		}.map {
+			ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
+		}.toList()
+		emitAll(filterLatestServices(client, datastoreInformation, results))
+	}
+
 	@View(name = "service_by_data_owner_tag_prefix", map = "classpath:js/contact/Service_by_data_owner_tag_prefix.js", secondaryPartition = BEPPE_PARTITION)
 	override fun listServiceIdsByDataOwnerTagCodePrefix(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
 		tagType: String,
 		tagCodePrefix: String,
-	): Flow<String> = listServiceIdsByDataOwnerTagOrCodePrefix(
+		startValueDate: Long?,
+		endValueDate: Long?,
+		): Flow<String> = listServiceIdsByDataOwnerTagOrCodePrefix(
 		datastoreInformation,
 		searchKeys,
 		tagType,
 		tagCodePrefix,
-		"listServiceIdsByDataOwnerTagCodePrefix",
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_tag_prefix",
 	)
 
 	@View(name = "service_by_data_owner_code_prefix", map = "classpath:js/contact/Service_by_data_owner_code_prefix.js", secondaryPartition = BEPPE_PARTITION)
@@ -1109,11 +1182,15 @@ class ContactDAOImpl(
 		searchKeys: Set<String>,
 		codeType: String,
 		codeCodePrefix: String,
+		startValueDate: Long?,
+		endValueDate: Long?,
 	): Flow<String> = listServiceIdsByDataOwnerTagOrCodePrefix(
 		datastoreInformation,
 		searchKeys,
 		codeType,
 		codeCodePrefix,
+		startValueDate,
+		endValueDate,
 		"service_by_data_owner_code_prefix",
 	)
 
@@ -1122,6 +1199,8 @@ class ContactDAOImpl(
 		searchKeys: Set<String>,
 		type: String,
 		codePrefix: String,
+		startValueDate: Long?,
+		endValueDate: Long?,
 		view: String,
 	): Flow<String> = flow {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
@@ -1140,8 +1219,12 @@ class ContactDAOImpl(
 				.startKey(from)
 				.endKey(to)
 				.includeDocs(false)
-			client.queryView<ComplexKey, String>(query).map {
-				ContactIdMandatoryServiceId(it.id, it.value!!)
+			client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
+				if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+			}.let { f ->
+				if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+			}.map {
+				ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
 			}
 		}
 		emitAll(filterLatestServices(
@@ -1149,6 +1232,68 @@ class ContactDAOImpl(
 			datastoreInformation,
 			allQueries.flatMapTo(mutableSetOf()) { it.toList() }
 		))
+	}
+
+	override fun listServiceIdsByDataOwnerTagCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		tagType: String,
+		tagCodes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): Flow<String> = listServiceIdsByDataOwnerTagOrCodeExact(
+		datastoreInformation,
+		searchKeys,
+		tagType,
+		tagCodes,
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_tag_prefix",
+	)
+
+	override fun listServiceIdsByDataOwnerCodeCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		codeType: String,
+		codeCodes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): Flow<String> = listServiceIdsByDataOwnerTagOrCodeExact(
+		datastoreInformation,
+		searchKeys,
+		codeType,
+		codeCodes,
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_code_prefix",
+	)
+
+	private fun listServiceIdsByDataOwnerTagOrCodeExact(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		type: String,
+		codes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+		view: String,
+	): Flow<String> = flow {
+		val client = couchDbDispatcher.getClient(datastoreInformation)
+		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
+			codes.map { code ->
+				ComplexKey.of(dataOwnerSearchKey, type, code)
+			}
+		}
+		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
+			.keys(keys)
+			.includeDocs(false)
+		val results = client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
+			if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+		}.let { f ->
+			if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+		}.map {
+			ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
+		}.toList()
+		emitAll(filterLatestServices(client, datastoreInformation, results))
 	}
 
 	@View(name = "service_by_data_owner_month_tag_prefix", map = "classpath:js/contact/Service_by_data_owner_month_tag_prefix.js", secondaryPartition = BEPPE_PARTITION)
@@ -1194,6 +1339,87 @@ class ContactDAOImpl(
 		endValueDate,
 		"service_by_data_owner_month_code_prefix",
 	)
+
+	override fun listServiceIdsByDataOwnerValueDateMonthTagCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		year: Int?,
+		month: Int?,
+		tagType: String,
+		tagCodes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): Flow<String> = listServiceIdsByDataOwnerValueDateMonthTagOrCodeExact(
+		datastoreInformation,
+		searchKeys,
+		year,
+		month,
+		tagType,
+		tagCodes,
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_month_tag_prefix",
+	)
+
+	override fun listServiceIdsByDataOwnerValueDateMonthCodeCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		year: Int?,
+		month: Int?,
+		codeType: String,
+		codeCodes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): Flow<String> = listServiceIdsByDataOwnerValueDateMonthTagOrCodeExact(
+		datastoreInformation,
+		searchKeys,
+		year,
+		month,
+		codeType,
+		codeCodes,
+		startValueDate,
+		endValueDate,
+		"service_by_data_owner_month_code_prefix",
+	)
+
+	private fun listServiceIdsByDataOwnerValueDateMonthTagOrCodeExact(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		year: Int?,
+		month: Int?,
+		type: String,
+		codes: Collection<String>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+		view: String,
+	): Flow<String> = flow {
+		require((year == null) == (month == null)) { "Year and month must both be non-null or both null" }
+		if (startValueDate != null) {
+			val parsed = FuzzyDates.getLocalDateTimeWithPrecision(startValueDate, false)?.first
+			require(parsed != null) { "startValueDate must be a valid fuzzy date time if provided" }
+		}
+		if (endValueDate != null) {
+			val parsed = FuzzyDates.getLocalDateTimeWithPrecision(endValueDate, false)?.first
+			require(parsed != null) { "startValueDate must be a valid fuzzy date time if provided" }
+		}
+		val client = couchDbDispatcher.getClient(datastoreInformation)
+		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
+			codes.map { code ->
+				ComplexKey.of(year, month, dataOwnerSearchKey, type, code)
+			}
+		}
+		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
+			.keys(keys)
+			.includeDocs(false)
+		val results = client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
+			if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+		}.let { f ->
+			if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+		}.map {
+			ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
+		}.toList()
+		emitAll(filterLatestServices(client, datastoreInformation, results))
+	}
 
 	private fun listServiceIdsByDataOwnerValueDateMonthTagOrCodePrefix(
 		datastoreInformation: IDatastoreInformation,
@@ -1294,8 +1520,10 @@ class ContactDAOImpl(
 				val jsonList = p.readValueAsTree<ArrayNode>()
 				check(jsonList.size() == 2) { "Expected exactly 2 items" }
 				check(jsonList[0].isTextual) { "Expected first item to be a string" }
-				check(jsonList[1].canConvertToLong() && !jsonList[1].isFloatingPointNumber) { "Expected second item to be a long" }
-				return ServiceIdAndDateValue(jsonList[0].textValue(), jsonList[1].longValue())
+
+				val isValueDateNull = jsonList[1].isNull
+				check(isValueDateNull || (jsonList[1].canConvertToLong() && !jsonList[1].isFloatingPointNumber)) { "Expected second item to be a long or null" }
+				return ServiceIdAndDateValue(jsonList[0].textValue(), if (isValueDateNull) null else jsonList[1].longValue())
 			}
 		}
 	}

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
@@ -1079,9 +1079,9 @@ class ContactDAOImpl(
 					.endKey(to)
 					.includeDocs(false)
 				client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-					if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+					if (startValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true } else f
 				}.let { f ->
-					if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+					if (endValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true } else f
 				}.map {
 					ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
 				}
@@ -1213,9 +1213,9 @@ class ContactDAOImpl(
 				.endKey(to)
 				.includeDocs(false)
 			client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-				if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+				if (startValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true } else f
 			}.let { f ->
-				if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+				if (endValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true } else f
 			}.map {
 				ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
 			}
@@ -1431,9 +1431,9 @@ class ContactDAOImpl(
 				.endKey(to)
 				.includeDocs(false)
 			client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-				if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+				if (startValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true } else f
 			}.let { f ->
-				if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+				if (endValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true } else f
 			}.map {
 				ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
 			}
@@ -1462,9 +1462,9 @@ class ContactDAOImpl(
 						.keys(chunkKeys)
 						.includeDocs(false)
 					client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-						if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+						if (startValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true } else f
 					}.let { f ->
-						if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+						if (endValueDate != null) f.filter { row -> row.value!!.date?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true } else f
 					}.map {
 						ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
 					}.toList()

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.node.ArrayNode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -22,6 +25,8 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Repository
@@ -1142,16 +1147,7 @@ class ContactDAOImpl(
 				}
 			}
 		}
-		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
-			.keys(keys)
-			.includeDocs(false)
-		val results = client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-			if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
-		}.let { f ->
-			if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
-		}.map {
-			ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
-		}.toList()
+		val results = queryViewByKeysInChunks(client, datastoreInformation, view, BEPPE_PARTITION, keys, startValueDate, endValueDate)
 		emitAll(filterLatestServices(client, datastoreInformation, results))
 	}
 
@@ -1277,16 +1273,7 @@ class ContactDAOImpl(
 				}
 			}
 		}
-		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
-			.keys(keys)
-			.includeDocs(false)
-		val results = client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-			if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
-		}.let { f ->
-			if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
-		}.map {
-			ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
-		}.toList()
+		val results = queryViewByKeysInChunks(client, datastoreInformation, view, BEPPE_PARTITION, keys, startValueDate, endValueDate)
 		emitAll(filterLatestServices(client, datastoreInformation, results))
 	}
 
@@ -1399,16 +1386,7 @@ class ContactDAOImpl(
 				}
 			}
 		}
-		val query = createQuery(datastoreInformation, view, BEPPE_PARTITION)
-			.keys(keys)
-			.includeDocs(false)
-		val results = client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
-			if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
-		}.let { f ->
-			if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
-		}.map {
-			ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
-		}.toList()
+		val results = queryViewByKeysInChunks(client, datastoreInformation, view, BEPPE_PARTITION, keys, startValueDate, endValueDate)
 		emitAll(filterLatestServices(client, datastoreInformation, results))
 	}
 
@@ -1465,6 +1443,34 @@ class ContactDAOImpl(
 			datastoreInformation,
 			allQueries.flatMapTo(mutableSetOf()) { it.toList() }
 		))
+	}
+
+	private suspend fun queryViewByKeysInChunks(
+		client: Client,
+		datastoreInformation: IDatastoreInformation,
+		view: String,
+		partition: String,
+		keys: List<ComplexKey>,
+		startValueDate: Long?,
+		endValueDate: Long?,
+	): List<ContactIdMandatoryServiceId> = coroutineScope {
+		val semaphore = Semaphore(daoConfig.viewQueryMaxConcurrency)
+		keys.chunked(daoConfig.viewQueryChunkSize).map { chunkKeys ->
+			async {
+				semaphore.withPermit {
+					val query = createQuery(datastoreInformation, view, partition)
+						.keys(chunkKeys)
+						.includeDocs(false)
+					client.queryView<ComplexKey, ServiceIdAndDateValue>(query).let { f ->
+						if (startValueDate != null) f.filter { row -> row.value!!.date?.let { it >= startValueDate } == true } else f
+					}.let { f ->
+						if (endValueDate != null) f.filter { row -> row.value!!.date?.let { it <= endValueDate } == true } else f
+					}.map {
+						ContactIdMandatoryServiceId(it.id, it.value!!.serviceId)
+					}.toList()
+				}
+			}
+		}.awaitAll().flatten()
 	}
 
 	@View(name = "by_service_latest", map = "classpath:js/contact/By_service_latest.js", reduce = "classpath:js/contact/By_service_latest_reduce.js", secondaryPartition = BEPPE_PARTITION)

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ContactDAOImpl.kt
@@ -1138,10 +1138,10 @@ class ContactDAOImpl(
 		view: String,
 	): Flow<String> = flow {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
-			patientSecretForeignKeys.flatMap { patientSecretForeignKey ->
-				typesAndCodes.flatMap { (type, codes) ->
-					codes.map { code ->
+		val keys = searchKeys.asSequence().flatMap { dataOwnerSearchKey ->
+			patientSecretForeignKeys.asSequence().flatMap { patientSecretForeignKey ->
+				typesAndCodes.asSequence().flatMap { (type, codes) ->
+					codes.asSequence().map { code ->
 						ComplexKey.of(dataOwnerSearchKey, patientSecretForeignKey, type, code)
 					}
 				}
@@ -1266,9 +1266,9 @@ class ContactDAOImpl(
 		view: String,
 	): Flow<String> = flow {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
-			typesAndCodes.flatMap { (type, codes) ->
-				codes.map { code ->
+		val keys = searchKeys.asSequence().flatMap { dataOwnerSearchKey ->
+			typesAndCodes.asSequence().flatMap { (type, codes) ->
+				codes.asSequence().map { code ->
 					ComplexKey.of(dataOwnerSearchKey, type, code)
 				}
 			}
@@ -1379,9 +1379,9 @@ class ContactDAOImpl(
 			require(parsed != null) { "endValueDate must be a valid fuzzy date time if provided" }
 		}
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		val keys = searchKeys.flatMap { dataOwnerSearchKey ->
-			typesAndCodes.flatMap { (type, codes) ->
-				codes.map { code ->
+		val keys = searchKeys.asSequence().flatMap { dataOwnerSearchKey ->
+			typesAndCodes.asSequence().flatMap { (type, codes) ->
+				codes.asSequence().map { code ->
 					ComplexKey.of(year, month, dataOwnerSearchKey, type, code)
 				}
 			}
@@ -1450,7 +1450,7 @@ class ContactDAOImpl(
 		datastoreInformation: IDatastoreInformation,
 		view: String,
 		partition: String,
-		keys: List<ComplexKey>,
+		keys: Sequence<ComplexKey>,
 		startValueDate: Long?,
 		endValueDate: Long?,
 	): List<ContactIdMandatoryServiceId> = coroutineScope {
@@ -1470,7 +1470,7 @@ class ContactDAOImpl(
 					}.toList()
 				}
 			}
-		}.awaitAll().flatten()
+		}.toList().awaitAll().flatten()
 	}
 
 	@View(name = "by_service_latest", map = "classpath:js/contact/By_service_latest.js", reduce = "classpath:js/contact/By_service_latest_reduce.js", secondaryPartition = BEPPE_PARTITION)

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodePrefixFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodePrefixFilter.kt
@@ -34,7 +34,7 @@ class ServiceByHcPartyCodePrefixFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodePrefixFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodePrefixFilter.kt
@@ -14,9 +14,7 @@ import org.taktik.icure.datastore.IDatastoreInformation
 import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodePrefixFilter
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.utils.FuzzyDates
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
+import org.taktik.icure.utils.FuzzyDates.maxPossibleFuzzyNowInAllTimeZones
 
 @org.springframework.stereotype.Service
 @Profile("app")
@@ -24,6 +22,10 @@ class ServiceByHcPartyCodePrefixFilter(
 	private val contactDAO: ContactDAO,
 	private val sessionLogic: SessionInformationProvider,
 ) : Filter<String, Service, ServiceByHcPartyCodePrefixFilter> {
+	companion object {
+		private const val MAX_MONTHS = 24
+	}
+
 	override fun resolve(
 		filter: ServiceByHcPartyCodePrefixFilter,
 		context: Filters,
@@ -34,8 +36,7 @@ class ServiceByHcPartyCodePrefixFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
-				ChronoUnit.SECONDS, false))
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: maxPossibleFuzzyNowInAllTimeZones(), MAX_MONTHS)
 		} else null
 
 		if (monthRange != null) {
@@ -71,3 +72,4 @@ class ServiceByHcPartyCodePrefixFilter(
 	}
 
 }
+

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
@@ -34,7 +34,7 @@ class ServiceByHcPartyCodesFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
@@ -32,47 +32,39 @@ class ServiceByHcPartyCodesFilter(
 		val startValueDate = filter.startValueDate
 		val endValueDate = filter.endValueDate
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
-		val emitted = mutableSetOf<String>()
 
 		val monthRange = if (startValueDate != null) {
 			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 
-		for ((codeType, codeCodes) in filter.codeCodes) {
-			if (monthRange != null) {
-				monthRange.forEachIndexed { index, (year, month) ->
-					val isFirst = index == 0
-					val isLast = index == monthRange.lastIndex
-					contactDAO.listServiceIdsByDataOwnerValueDateMonthCodeCodes(
-						datastoreInformation = datastoreInformation,
-						searchKeys = searchKeys,
-						year = year,
-						month = month,
-						codeType = codeType,
-						codeCodes = codeCodes,
-						startValueDate = if (isFirst) startValueDate else null,
-						endValueDate = if (isLast) endValueDate else null,
-					).collect { serviceId ->
-						if (emitted.add(serviceId)) {
-							emit(serviceId)
-						}
-					}
-				}
-			} else {
-				contactDAO.listServiceIdsByDataOwnerCodeCodes(
+		if (monthRange != null) {
+			val emitted = mutableSetOf<String>()
+			monthRange.forEachIndexed { index, (year, month) ->
+				val isFirst = index == 0
+				val isLast = index == monthRange.lastIndex
+				contactDAO.listServiceIdsByDataOwnerValueDateMonthCodeCodes(
 					datastoreInformation = datastoreInformation,
 					searchKeys = searchKeys,
-					codeType = codeType,
-					codeCodes = codeCodes,
-					startValueDate = startValueDate,
-					endValueDate = endValueDate,
+					year = year,
+					month = month,
+					codeTypesAndCodes = filter.codeCodes,
+					startValueDate = if (isFirst) startValueDate else null,
+					endValueDate = if (isLast) endValueDate else null,
 				).collect { serviceId ->
 					if (emitted.add(serviceId)) {
 						emit(serviceId)
 					}
 				}
 			}
+		} else {
+			emitAll(contactDAO.listServiceIdsByDataOwnerCodeCodes(
+				datastoreInformation = datastoreInformation,
+				searchKeys = searchKeys,
+				codeTypesAndCodes = filter.codeCodes,
+				startValueDate = startValueDate,
+				endValueDate = endValueDate,
+			))
 		}
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
@@ -11,7 +11,7 @@ import org.taktik.icure.asynclogic.SessionInformationProvider
 import org.taktik.icure.asynclogic.impl.filter.Filter
 import org.taktik.icure.asynclogic.impl.filter.Filters
 import org.taktik.icure.datastore.IDatastoreInformation
-import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodePrefixFilter
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodesFilter
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.utils.FuzzyDates
 import java.time.LocalDateTime
@@ -20,54 +20,59 @@ import java.time.temporal.ChronoUnit
 
 @org.springframework.stereotype.Service
 @Profile("app")
-class ServiceByHcPartyCodePrefixFilter(
+class ServiceByHcPartyCodesFilter(
 	private val contactDAO: ContactDAO,
 	private val sessionLogic: SessionInformationProvider,
-) : Filter<String, Service, ServiceByHcPartyCodePrefixFilter> {
+) : Filter<String, Service, ServiceByHcPartyCodesFilter> {
 	override fun resolve(
-		filter: ServiceByHcPartyCodePrefixFilter,
+		filter: ServiceByHcPartyCodesFilter,
 		context: Filters,
 		datastoreInformation: IDatastoreInformation,
 	) = flow {
 		val startValueDate = filter.startValueDate
 		val endValueDate = filter.endValueDate
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
+		val emitted = mutableSetOf<String>()
 
 		val monthRange = if (startValueDate != null) {
 			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 
-		if (monthRange != null) {
-			val emitted = mutableSetOf<String>()
-			monthRange.forEachIndexed { index, (year, month) ->
-				val isFirst = index == 0
-				val isLast = index == monthRange.lastIndex
-				contactDAO.listServiceIdsByDataOwnerValueDateMonthCodeCodePrefix(
+		for ((codeType, codeCodes) in filter.codeCodes) {
+			if (monthRange != null) {
+				monthRange.forEachIndexed { index, (year, month) ->
+					val isFirst = index == 0
+					val isLast = index == monthRange.lastIndex
+					contactDAO.listServiceIdsByDataOwnerValueDateMonthCodeCodes(
+						datastoreInformation = datastoreInformation,
+						searchKeys = searchKeys,
+						year = year,
+						month = month,
+						codeType = codeType,
+						codeCodes = codeCodes,
+						startValueDate = if (isFirst) startValueDate else null,
+						endValueDate = if (isLast) endValueDate else null,
+					).collect { serviceId ->
+						if (emitted.add(serviceId)) {
+							emit(serviceId)
+						}
+					}
+				}
+			} else {
+				contactDAO.listServiceIdsByDataOwnerCodeCodes(
 					datastoreInformation = datastoreInformation,
 					searchKeys = searchKeys,
-					year = year,
-					month = month,
-					codeType = filter.codeType,
-					codeCodePrefix = filter.codeCodePrefix,
-					startValueDate = if (isFirst) startValueDate else null,
-					endValueDate = if (isLast) endValueDate else null,
+					codeType = codeType,
+					codeCodes = codeCodes,
+					startValueDate = startValueDate,
+					endValueDate = endValueDate,
 				).collect { serviceId ->
 					if (emitted.add(serviceId)) {
 						emit(serviceId)
 					}
 				}
 			}
-		} else {
-			emitAll(contactDAO.listServiceIdsByDataOwnerCodeCodePrefix(
-				datastoreInformation = datastoreInformation,
-				searchKeys = searchKeys,
-				codeType = filter.codeType,
-				codeCodePrefix = filter.codeCodePrefix,
-				startValueDate = startValueDate,
-				endValueDate = endValueDate,
-			))
 		}
 	}
-
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyCodesFilter.kt
@@ -14,6 +14,7 @@ import org.taktik.icure.datastore.IDatastoreInformation
 import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodesFilter
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.utils.FuzzyDates
+import org.taktik.icure.utils.FuzzyDates.maxPossibleFuzzyNowInAllTimeZones
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -24,6 +25,10 @@ class ServiceByHcPartyCodesFilter(
 	private val contactDAO: ContactDAO,
 	private val sessionLogic: SessionInformationProvider,
 ) : Filter<String, Service, ServiceByHcPartyCodesFilter> {
+	companion object {
+		private const val MAX_MONTHS = 24
+	}
+
 	override fun resolve(
 		filter: ServiceByHcPartyCodesFilter,
 		context: Filters,
@@ -34,8 +39,7 @@ class ServiceByHcPartyCodesFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
-				ChronoUnit.SECONDS, false))
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: maxPossibleFuzzyNowInAllTimeZones(), MAX_MONTHS)
 		} else null
 
 		if (monthRange != null) {

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientCodesFilter.kt
@@ -25,23 +25,13 @@ class ServiceByHcPartyPatientCodesFilter(
 		context: Filters,
 		datastoreInformation: IDatastoreInformation,
 	) = flow {
-		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
-		val emitted = mutableSetOf<String>()
-
-		for ((codeType, codeCodes) in filter.codeCodes) {
-			contactDAO.listServiceIdsByDataOwnerPatientCodeCodes(
-				datastoreInformation = datastoreInformation,
-				searchKeys = searchKeys,
-				patientSecretForeignKeys = filter.patientSecretForeignKeys,
-				codeType = codeType,
-				codeCodes = codeCodes,
-				startValueDate = filter.startValueDate,
-				endValueDate = filter.endValueDate,
-			).collect { serviceId ->
-				if (emitted.add(serviceId)) {
-					emit(serviceId)
-				}
-			}
-		}
+		emitAll(contactDAO.listServiceIdsByDataOwnerPatientCodeCodes(
+			datastoreInformation = datastoreInformation,
+			searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId),
+			patientSecretForeignKeys = filter.patientSecretForeignKeys,
+			codeTypesAndCodes = filter.codeCodes,
+			startValueDate = filter.startValueDate,
+			endValueDate = filter.endValueDate,
+		))
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientCodesFilter.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020. Taktik SA, All rights reserved.
+ */
+package org.taktik.icure.asynclogic.impl.filter.service
+
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import org.springframework.context.annotation.Profile
+import org.taktik.icure.asyncdao.ContactDAO
+import org.taktik.icure.asynclogic.SessionInformationProvider
+import org.taktik.icure.asynclogic.impl.filter.Filter
+import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.datastore.IDatastoreInformation
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientCodesFilter
+import org.taktik.icure.entities.embed.Service
+
+@org.springframework.stereotype.Service
+@Profile("app")
+class ServiceByHcPartyPatientCodesFilter(
+	private val contactDAO: ContactDAO,
+	private val sessionLogic: SessionInformationProvider,
+) : Filter<String, Service, ServiceByHcPartyPatientCodesFilter> {
+	override fun resolve(
+		filter: ServiceByHcPartyPatientCodesFilter,
+		context: Filters,
+		datastoreInformation: IDatastoreInformation,
+	) = flow {
+		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
+		val emitted = mutableSetOf<String>()
+
+		for ((codeType, codeCodes) in filter.codeCodes) {
+			contactDAO.listServiceIdsByDataOwnerPatientCodeCodes(
+				datastoreInformation = datastoreInformation,
+				searchKeys = searchKeys,
+				patientSecretForeignKeys = filter.patientSecretForeignKeys,
+				codeType = codeType,
+				codeCodes = codeCodes,
+				startValueDate = filter.startValueDate,
+				endValueDate = filter.endValueDate,
+			).collect { serviceId ->
+				if (emitted.add(serviceId)) {
+					emit(serviceId)
+				}
+			}
+		}
+	}
+}

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
@@ -25,23 +25,13 @@ class ServiceByHcPartyPatientTagCodesFilter(
 		context: Filters,
 		datastoreInformation: IDatastoreInformation,
 	) = flow {
-		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
-		val emitted = mutableSetOf<String>()
-
-		for ((tagType, tagCodes) in filter.tagCodes) {
-			contactDAO.listServiceIdsByDataOwnerPatientTagCodes(
-				datastoreInformation = datastoreInformation,
-				searchKeys = searchKeys,
-				patientSecretForeignKeys = filter.patientSecretForeignKeys,
-				tagType = tagType,
-				tagCodes = tagCodes,
-				startValueDate = filter.startValueDate,
-				endValueDate = filter.endValueDate,
-			).collect { serviceId ->
-				if (emitted.add(serviceId)) {
-					emit(serviceId)
-				}
-			}
-		}
+		emitAll(contactDAO.listServiceIdsByDataOwnerPatientTagCodes(
+			datastoreInformation = datastoreInformation,
+			searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId),
+			patientSecretForeignKeys = filter.patientSecretForeignKeys,
+			tagTypesAndCodes = filter.tagCodes,
+			startValueDate = filter.startValueDate,
+			endValueDate = filter.endValueDate,
+		))
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020. Taktik SA, All rights reserved.
+ */
+package org.taktik.icure.asynclogic.impl.filter.service
+
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import org.springframework.context.annotation.Profile
+import org.taktik.icure.asyncdao.ContactDAO
+import org.taktik.icure.asynclogic.SessionInformationProvider
+import org.taktik.icure.asynclogic.impl.filter.Filter
+import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.datastore.IDatastoreInformation
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientTagCodesFilter
+import org.taktik.icure.entities.embed.Service
+
+@org.springframework.stereotype.Service
+@Profile("app")
+class ServiceByHcPartyPatientTagCodesFilter(
+	private val contactDAO: ContactDAO,
+	private val sessionLogic: SessionInformationProvider,
+) : Filter<String, Service, ServiceByHcPartyPatientTagCodesFilter> {
+	override fun resolve(
+		filter: ServiceByHcPartyPatientTagCodesFilter,
+		context: Filters,
+		datastoreInformation: IDatastoreInformation,
+	) = flow {
+		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
+		val emitted = mutableSetOf<String>()
+
+		for ((tagType, tagCodes) in filter.tagCodes) {
+			contactDAO.listServiceIdsByDataOwnerPatientTagCodes(
+				datastoreInformation = datastoreInformation,
+				searchKeys = searchKeys,
+				patientSecretForeignKeys = filter.patientSecretForeignKeys,
+				tagType = tagType,
+				tagCodes = tagCodes,
+				startValueDate = filter.startValueDate,
+				endValueDate = filter.endValueDate,
+			).collect { serviceId ->
+				if (emitted.add(serviceId)) {
+					emit(serviceId)
+				}
+			}
+		}
+	}
+}

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
@@ -32,47 +32,39 @@ class ServiceByHcPartyTagCodesFilter(
 		val startValueDate = filter.startValueDate
 		val endValueDate = filter.endValueDate
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
-		val emitted = mutableSetOf<String>()
 
 		val monthRange = if (startValueDate != null) {
 			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 
-		for ((tagType, tagCodes) in filter.tagCodes) {
-			if (monthRange != null) {
-				monthRange.forEachIndexed { index, (year, month) ->
-					val isFirst = index == 0
-					val isLast = index == monthRange.lastIndex
-					contactDAO.listServiceIdsByDataOwnerValueDateMonthTagCodes(
-						datastoreInformation = datastoreInformation,
-						searchKeys = searchKeys,
-						year = year,
-						month = month,
-						tagType = tagType,
-						tagCodes = tagCodes,
-						startValueDate = if (isFirst) startValueDate else null,
-						endValueDate = if (isLast) endValueDate else null,
-					).collect { serviceId ->
-						if (emitted.add(serviceId)) {
-							emit(serviceId)
-						}
-					}
-				}
-			} else {
-				contactDAO.listServiceIdsByDataOwnerTagCodes(
+		if (monthRange != null) {
+			val emitted = mutableSetOf<String>()
+			monthRange.forEachIndexed { index, (year, month) ->
+				val isFirst = index == 0
+				val isLast = index == monthRange.lastIndex
+				contactDAO.listServiceIdsByDataOwnerValueDateMonthTagCodes(
 					datastoreInformation = datastoreInformation,
 					searchKeys = searchKeys,
-					tagType = tagType,
-					tagCodes = tagCodes,
-					startValueDate = startValueDate,
-					endValueDate = endValueDate,
+					year = year,
+					month = month,
+					tagTypesAndCodes = filter.tagCodes,
+					startValueDate = if (isFirst) startValueDate else null,
+					endValueDate = if (isLast) endValueDate else null,
 				).collect { serviceId ->
 					if (emitted.add(serviceId)) {
 						emit(serviceId)
 					}
 				}
 			}
+		} else {
+			emitAll(contactDAO.listServiceIdsByDataOwnerTagCodes(
+				datastoreInformation = datastoreInformation,
+				searchKeys = searchKeys,
+				tagTypesAndCodes = filter.tagCodes,
+				startValueDate = startValueDate,
+				endValueDate = endValueDate,
+			))
 		}
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
@@ -14,6 +14,7 @@ import org.taktik.icure.datastore.IDatastoreInformation
 import org.taktik.icure.domain.filter.service.ServiceByHcPartyTagCodesFilter
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.utils.FuzzyDates
+import org.taktik.icure.utils.FuzzyDates.maxPossibleFuzzyNowInAllTimeZones
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
@@ -24,6 +25,10 @@ class ServiceByHcPartyTagCodesFilter(
 	private val contactDAO: ContactDAO,
 	private val sessionLogic: SessionInformationProvider,
 ) : Filter<String, Service, ServiceByHcPartyTagCodesFilter> {
+	companion object {
+		private const val MAX_MONTHS = 24
+	}
+
 	override fun resolve(
 		filter: ServiceByHcPartyTagCodesFilter,
 		context: Filters,
@@ -34,8 +39,7 @@ class ServiceByHcPartyTagCodesFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
-				ChronoUnit.SECONDS, false))
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: maxPossibleFuzzyNowInAllTimeZones(), MAX_MONTHS)
 		} else null
 
 		if (monthRange != null) {

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
@@ -34,7 +34,7 @@ class ServiceByHcPartyTagCodesFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagCodesFilter.kt
@@ -11,7 +11,7 @@ import org.taktik.icure.asynclogic.SessionInformationProvider
 import org.taktik.icure.asynclogic.impl.filter.Filter
 import org.taktik.icure.asynclogic.impl.filter.Filters
 import org.taktik.icure.datastore.IDatastoreInformation
-import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodePrefixFilter
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyTagCodesFilter
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.utils.FuzzyDates
 import java.time.LocalDateTime
@@ -20,54 +20,59 @@ import java.time.temporal.ChronoUnit
 
 @org.springframework.stereotype.Service
 @Profile("app")
-class ServiceByHcPartyCodePrefixFilter(
+class ServiceByHcPartyTagCodesFilter(
 	private val contactDAO: ContactDAO,
 	private val sessionLogic: SessionInformationProvider,
-) : Filter<String, Service, ServiceByHcPartyCodePrefixFilter> {
+) : Filter<String, Service, ServiceByHcPartyTagCodesFilter> {
 	override fun resolve(
-		filter: ServiceByHcPartyCodePrefixFilter,
+		filter: ServiceByHcPartyTagCodesFilter,
 		context: Filters,
 		datastoreInformation: IDatastoreInformation,
 	) = flow {
 		val startValueDate = filter.startValueDate
 		val endValueDate = filter.endValueDate
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
+		val emitted = mutableSetOf<String>()
 
 		val monthRange = if (startValueDate != null) {
 			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 
-		if (monthRange != null) {
-			val emitted = mutableSetOf<String>()
-			monthRange.forEachIndexed { index, (year, month) ->
-				val isFirst = index == 0
-				val isLast = index == monthRange.lastIndex
-				contactDAO.listServiceIdsByDataOwnerValueDateMonthCodeCodePrefix(
+		for ((tagType, tagCodes) in filter.tagCodes) {
+			if (monthRange != null) {
+				monthRange.forEachIndexed { index, (year, month) ->
+					val isFirst = index == 0
+					val isLast = index == monthRange.lastIndex
+					contactDAO.listServiceIdsByDataOwnerValueDateMonthTagCodes(
+						datastoreInformation = datastoreInformation,
+						searchKeys = searchKeys,
+						year = year,
+						month = month,
+						tagType = tagType,
+						tagCodes = tagCodes,
+						startValueDate = if (isFirst) startValueDate else null,
+						endValueDate = if (isLast) endValueDate else null,
+					).collect { serviceId ->
+						if (emitted.add(serviceId)) {
+							emit(serviceId)
+						}
+					}
+				}
+			} else {
+				contactDAO.listServiceIdsByDataOwnerTagCodes(
 					datastoreInformation = datastoreInformation,
 					searchKeys = searchKeys,
-					year = year,
-					month = month,
-					codeType = filter.codeType,
-					codeCodePrefix = filter.codeCodePrefix,
-					startValueDate = if (isFirst) startValueDate else null,
-					endValueDate = if (isLast) endValueDate else null,
+					tagType = tagType,
+					tagCodes = tagCodes,
+					startValueDate = startValueDate,
+					endValueDate = endValueDate,
 				).collect { serviceId ->
 					if (emitted.add(serviceId)) {
 						emit(serviceId)
 					}
 				}
 			}
-		} else {
-			emitAll(contactDAO.listServiceIdsByDataOwnerCodeCodePrefix(
-				datastoreInformation = datastoreInformation,
-				searchKeys = searchKeys,
-				codeType = filter.codeType,
-				codeCodePrefix = filter.codeCodePrefix,
-				startValueDate = startValueDate,
-				endValueDate = endValueDate,
-			))
 		}
 	}
-
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagPrefixFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagPrefixFilter.kt
@@ -11,9 +11,12 @@ import org.taktik.icure.asynclogic.SessionInformationProvider
 import org.taktik.icure.asynclogic.impl.filter.Filter
 import org.taktik.icure.asynclogic.impl.filter.Filters
 import org.taktik.icure.datastore.IDatastoreInformation
-import org.taktik.icure.domain.filter.service.ServiceByHcPartyMonthTagPrefixFilter
 import org.taktik.icure.domain.filter.service.ServiceByHcPartyTagPrefixFilter
 import org.taktik.icure.entities.embed.Service
+import org.taktik.icure.utils.FuzzyDates
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 @org.springframework.stereotype.Service
 @Profile("app")
@@ -26,11 +29,44 @@ class ServiceByHcPartyTagPrefixFilter(
 		context: Filters,
 		datastoreInformation: IDatastoreInformation,
 	) = flow {
-		emitAll(contactDAO.listServiceIdsByDataOwnerTagCodePrefix(
-			datastoreInformation = datastoreInformation,
-			searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId),
-			tagType = filter.tagType,
-			tagCodePrefix = filter.tagCodePrefix,
-		))
+		val startValueDate = filter.startValueDate
+		val endValueDate = filter.endValueDate
+		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
+
+		val monthRange = if (startValueDate != null) {
+			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
+				ChronoUnit.SECONDS, false))
+		} else null
+
+		if (monthRange != null) {
+			val emitted = mutableSetOf<String>()
+			monthRange.forEachIndexed { index, (year, month) ->
+				val isFirst = index == 0
+				val isLast = index == monthRange.lastIndex
+				contactDAO.listServiceIdsByDataOwnerValueDateMonthTagCodePrefix(
+					datastoreInformation = datastoreInformation,
+					searchKeys = searchKeys,
+					year = year,
+					month = month,
+					tagType = filter.tagType,
+					tagCodePrefix = filter.tagCodePrefix,
+					startValueDate = if (isFirst) startValueDate else null,
+					endValueDate = if (isLast) endValueDate else null,
+				).collect { serviceId ->
+					if (emitted.add(serviceId)) {
+						emit(serviceId)
+					}
+				}
+			}
+		} else {
+			emitAll(contactDAO.listServiceIdsByDataOwnerTagCodePrefix(
+				datastoreInformation = datastoreInformation,
+				searchKeys = searchKeys,
+				tagType = filter.tagType,
+				tagCodePrefix = filter.tagCodePrefix,
+				startValueDate = startValueDate,
+				endValueDate = endValueDate,
+			))
+		}
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagPrefixFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagPrefixFilter.kt
@@ -34,7 +34,7 @@ class ServiceByHcPartyTagPrefixFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
 				ChronoUnit.SECONDS, false))
 		} else null
 

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagPrefixFilter.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/filter/service/ServiceByHcPartyTagPrefixFilter.kt
@@ -14,9 +14,7 @@ import org.taktik.icure.datastore.IDatastoreInformation
 import org.taktik.icure.domain.filter.service.ServiceByHcPartyTagPrefixFilter
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.utils.FuzzyDates
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
+import org.taktik.icure.utils.FuzzyDates.maxPossibleFuzzyNowInAllTimeZones
 
 @org.springframework.stereotype.Service
 @Profile("app")
@@ -24,6 +22,10 @@ class ServiceByHcPartyTagPrefixFilter(
 	private val contactDAO: ContactDAO,
 	private val sessionLogic: SessionInformationProvider,
 ) : Filter<String, Service, ServiceByHcPartyTagPrefixFilter> {
+	companion object {
+		private const val MAX_MONTHS = 24
+	}
+
 	override fun resolve(
 		filter: ServiceByHcPartyTagPrefixFilter,
 		context: Filters,
@@ -34,8 +36,7 @@ class ServiceByHcPartyTagPrefixFilter(
 		val searchKeys = sessionLogic.getAllSearchKeysIfCurrentDataOwner(filter.healthcarePartyId)
 
 		val monthRange = if (startValueDate != null) {
-			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: FuzzyDates.getFuzzyDateTime(LocalDateTime.now(ZoneId.ofOffset("UTC", java.time.ZoneOffset.ofHours(14))),
-				ChronoUnit.SECONDS, false))
+			FuzzyDates.getMonthRange(startValueDate, endValueDate ?: maxPossibleFuzzyNowInAllTimeZones(), MAX_MONTHS)
 		} else null
 
 		if (monthRange != null) {

--- a/core/src/main/kotlin/org/taktik/icure/config/DaoConfig.kt
+++ b/core/src/main/kotlin/org/taktik/icure/config/DaoConfig.kt
@@ -3,4 +3,6 @@ package org.taktik.icure.config
 interface DaoConfig {
 	val useDataOwnerPartition: Boolean
 	val useObsoleteViews: Boolean
+	val viewQueryChunkSize: Int get() = 1000
+	val viewQueryMaxConcurrency: Int get() = 4
 }

--- a/dao/src/main/kotlin/org/taktik/icure/asyncdao/ContactDAO.kt
+++ b/dao/src/main/kotlin/org/taktik/icure/asyncdao/ContactDAO.kt
@@ -403,8 +403,7 @@ interface ContactDAO : ConflictDAO<Contact> {
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
 		patientSecretForeignKeys: Set<String>,
-		tagType: String,
-		tagCodes: Collection<String>,
+		tagTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long? = null,
 		endValueDate: Long? = null,
 	): Flow<String>
@@ -413,8 +412,7 @@ interface ContactDAO : ConflictDAO<Contact> {
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
 		patientSecretForeignKeys: Set<String>,
-		codeType: String,
-		codeCodes: Collection<String>,
+		codeTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long? = null,
 		endValueDate: Long? = null,
 	): Flow<String>
@@ -465,8 +463,7 @@ interface ContactDAO : ConflictDAO<Contact> {
 		searchKeys: Set<String>,
 		year: Int?,
 		month: Int?,
-		tagType: String,
-		tagCodes: Collection<String>,
+		tagTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long? = null,
 		endValueDate: Long? = null,
 	): Flow<String>
@@ -476,8 +473,7 @@ interface ContactDAO : ConflictDAO<Contact> {
 		searchKeys: Set<String>,
 		year: Int?,
 		month: Int?,
-		codeType: String,
-		codeCodes: Collection<String>,
+		codeTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long? = null,
 		endValueDate: Long? = null,
 	): Flow<String>
@@ -485,8 +481,7 @@ interface ContactDAO : ConflictDAO<Contact> {
 	fun listServiceIdsByDataOwnerTagCodes(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
-		tagType: String,
-		tagCodes: Collection<String>,
+		tagTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long? = null,
 		endValueDate: Long? = null,
 	): Flow<String>
@@ -494,8 +489,7 @@ interface ContactDAO : ConflictDAO<Contact> {
 	fun listServiceIdsByDataOwnerCodeCodes(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
-		codeType: String,
-		codeCodes: Collection<String>,
+		codeTypesAndCodes: Map<String, Collection<String>>,
 		startValueDate: Long? = null,
 		endValueDate: Long? = null,
 	): Flow<String>

--- a/dao/src/main/kotlin/org/taktik/icure/asyncdao/ContactDAO.kt
+++ b/dao/src/main/kotlin/org/taktik/icure/asyncdao/ContactDAO.kt
@@ -399,6 +399,26 @@ interface ContactDAO : ConflictDAO<Contact> {
 		endValueDate: Long?,
 	): Flow<String>
 
+	fun listServiceIdsByDataOwnerPatientTagCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		patientSecretForeignKeys: Set<String>,
+		tagType: String,
+		tagCodes: Collection<String>,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
+	): Flow<String>
+
+	fun listServiceIdsByDataOwnerPatientCodeCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		patientSecretForeignKeys: Set<String>,
+		codeType: String,
+		codeCodes: Collection<String>,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
+	): Flow<String>
+
 	fun listServiceIdsByDataOwnerValueDateMonthTagCodePrefix(
 		datastoreInformation: IDatastoreInformation,
 		searchKeys: Set<String>,
@@ -427,6 +447,8 @@ interface ContactDAO : ConflictDAO<Contact> {
 		searchKeys: Set<String>,
 		tagType: String,
 		tagCodePrefix: String,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
 	): Flow<String>
 
 	fun listServiceIdsByDataOwnerCodeCodePrefix(
@@ -434,6 +456,48 @@ interface ContactDAO : ConflictDAO<Contact> {
 		searchKeys: Set<String>,
 		codeType: String,
 		codeCodePrefix: String,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
+	): Flow<String>
+
+	fun listServiceIdsByDataOwnerValueDateMonthTagCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		year: Int?,
+		month: Int?,
+		tagType: String,
+		tagCodes: Collection<String>,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
+	): Flow<String>
+
+	fun listServiceIdsByDataOwnerValueDateMonthCodeCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		year: Int?,
+		month: Int?,
+		codeType: String,
+		codeCodes: Collection<String>,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
+	): Flow<String>
+
+	fun listServiceIdsByDataOwnerTagCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		tagType: String,
+		tagCodes: Collection<String>,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
+	): Flow<String>
+
+	fun listServiceIdsByDataOwnerCodeCodes(
+		datastoreInformation: IDatastoreInformation,
+		searchKeys: Set<String>,
+		codeType: String,
+		codeCodes: Collection<String>,
+		startValueDate: Long? = null,
+		endValueDate: Long? = null,
 	): Flow<String>
 	// endregion
 }

--- a/dao/src/main/resources/org/taktik/icure/asyncdao/impl/js/contact/Service_by_data_owner_code_prefix.js
+++ b/dao/src/main/resources/org/taktik/icure/asyncdao/impl/js/contact/Service_by_data_owner_code_prefix.js
@@ -25,7 +25,7 @@ function(doc) {
       if (service.codes && service.codes.length && service._id != null) {
         service.codes.forEach(function (code) {
           for (const delegate of delegates) {
-            emit([delegate, code.type, code.code], service._id);
+            emit([delegate, code.type, code.code], [service._id, service.valueDate || service.openingDate]);
           }
         });
       }

--- a/dao/src/main/resources/org/taktik/icure/asyncdao/impl/js/contact/Service_by_data_owner_tag_prefix.js
+++ b/dao/src/main/resources/org/taktik/icure/asyncdao/impl/js/contact/Service_by_data_owner_tag_prefix.js
@@ -25,7 +25,7 @@ function(doc) {
       if (service.tags && service.tags.length && service._id != null) {
         service.tags.forEach(function (tag) {
           for (const delegate of delegates) {
-            emit([delegate, tag.type, tag.code], service._id);
+            emit([delegate, tag.type, tag.code], [service._id, service.valueDate || service.openingDate]);
           }
         });
       }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyCodesFilter.kt
@@ -4,19 +4,18 @@
 package org.taktik.icure.domain.filter.impl.service
 
 import org.taktik.icure.domain.filter.AbstractFilter
-import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodePrefixFilter
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodesFilter
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.embed.Service
 
-data class ServiceByHcPartyCodePrefixFilter(
+data class ServiceByHcPartyCodesFilter(
 	override val desc: String? = null,
 	override val healthcarePartyId: String,
-	override val codeType: String,
-	override val codeCodePrefix: String,
+	override val codeCodes: Map<String, Collection<String>>,
 	override val startValueDate: Long? = null,
 	override val endValueDate: Long? = null,
 ) : AbstractFilter<Service>,
-	ServiceByHcPartyCodePrefixFilter {
+	ServiceByHcPartyCodesFilter {
 
 	override val canBeUsedInWebsocket = false
 	override val requiresSecurityPrecondition: Boolean = false

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientCodePrefixFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientCodePrefixFilter.kt
@@ -8,6 +8,7 @@ import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientCodePrefixF
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.entities.embed.withEncryptionMetadata
+import org.taktik.icure.utils.FuzzyDates
 
 data class ServiceByHcPartyPatientCodePrefixFilter(
 	override val desc: String? = null,
@@ -30,7 +31,7 @@ data class ServiceByHcPartyPatientCodePrefixFilter(
 			(item.withEncryptionMetadata()?.let { searchKeyMatcher(healthcarePartyId, it) } == true) &&
 			(item.secretForeignKeys?.intersect(patientSecretForeignKeys.toSet())?.isNotEmpty() == true) &&
 			(item.codes.any { codeType == it.type && it.code?.startsWith(codeCodePrefix) == true }) &&
-			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { it >= startValueDate } == true) &&
-			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { it <= endValueDate } == true)
+			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true) &&
+			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true)
 		)
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientCodesFilter.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020. Taktik SA, All rights reserved.
+ */
+package org.taktik.icure.domain.filter.impl.service
+
+import org.taktik.icure.domain.filter.AbstractFilter
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientCodesFilter
+import org.taktik.icure.entities.base.HasEncryptionMetadata
+import org.taktik.icure.entities.embed.Service
+import org.taktik.icure.entities.embed.withEncryptionMetadata
+
+data class ServiceByHcPartyPatientCodesFilter(
+	override val desc: String? = null,
+	override val healthcarePartyId: String,
+	override val patientSecretForeignKeys: Set<String>,
+	override val codeCodes: Map<String, Collection<String>>,
+	override val startValueDate: Long? = null,
+	override val endValueDate: Long? = null
+
+) : AbstractFilter<Service>,
+	ServiceByHcPartyPatientCodesFilter {
+
+	override val canBeUsedInWebsocket = true
+	override val requiresSecurityPrecondition: Boolean = false
+	override fun requestedDataOwnerIds(): Set<String> = setOf(healthcarePartyId)
+
+	override fun matches(item: Service, searchKeyMatcher: (String, HasEncryptionMetadata) -> Boolean): Boolean = (
+		item.endOfLife == null &&
+			(item.withEncryptionMetadata()?.let { searchKeyMatcher(healthcarePartyId, it) } == true) &&
+			(item.secretForeignKeys?.intersect(patientSecretForeignKeys.toSet())?.isNotEmpty() == true) &&
+			(item.codes.any { codeCodes[it.type]?.let { codes -> it.code in codes } == true }) &&
+			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { it >= startValueDate } == true) &&
+			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { it <= endValueDate } == true)
+		)
+}

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientCodesFilter.kt
@@ -8,6 +8,7 @@ import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientCodesFilter
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.entities.embed.withEncryptionMetadata
+import org.taktik.icure.utils.FuzzyDates
 
 data class ServiceByHcPartyPatientCodesFilter(
 	override val desc: String? = null,
@@ -29,7 +30,7 @@ data class ServiceByHcPartyPatientCodesFilter(
 			(item.withEncryptionMetadata()?.let { searchKeyMatcher(healthcarePartyId, it) } == true) &&
 			(item.secretForeignKeys?.intersect(patientSecretForeignKeys.toSet())?.isNotEmpty() == true) &&
 			(item.codes.any { codeCodes[it.type]?.let { codes -> it.code in codes } == true }) &&
-			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { it >= startValueDate } == true) &&
-			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { it <= endValueDate } == true)
+			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true) &&
+			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true)
 		)
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientTagCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientTagCodesFilter.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020. Taktik SA, All rights reserved.
+ */
+package org.taktik.icure.domain.filter.impl.service
+
+import org.taktik.icure.domain.filter.AbstractFilter
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientTagCodesFilter
+import org.taktik.icure.entities.base.HasEncryptionMetadata
+import org.taktik.icure.entities.embed.Service
+import org.taktik.icure.entities.embed.withEncryptionMetadata
+
+data class ServiceByHcPartyPatientTagCodesFilter(
+	override val desc: String? = null,
+	override val healthcarePartyId: String,
+	override val patientSecretForeignKeys: Set<String>,
+	override val tagCodes: Map<String, Collection<String>>,
+	override val startValueDate: Long? = null,
+	override val endValueDate: Long? = null
+
+) : AbstractFilter<Service>,
+	ServiceByHcPartyPatientTagCodesFilter {
+
+	override val canBeUsedInWebsocket = true
+	override val requiresSecurityPrecondition: Boolean = false
+	override fun requestedDataOwnerIds(): Set<String> = setOf(healthcarePartyId)
+
+	override fun matches(item: Service, searchKeyMatcher: (String, HasEncryptionMetadata) -> Boolean): Boolean = (
+		item.endOfLife == null &&
+			(item.withEncryptionMetadata()?.let { searchKeyMatcher(healthcarePartyId, it) } == true) &&
+			(item.secretForeignKeys?.intersect(patientSecretForeignKeys.toSet())?.isNotEmpty() == true) &&
+			(item.tags.any { tagCodes[it.type]?.let { codes -> it.code in codes } == true }) &&
+			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { it >= startValueDate } == true) &&
+			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { it <= endValueDate } == true)
+		)
+}

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientTagCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientTagCodesFilter.kt
@@ -8,6 +8,7 @@ import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientTagCodesFil
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.entities.embed.withEncryptionMetadata
+import org.taktik.icure.utils.FuzzyDates
 
 data class ServiceByHcPartyPatientTagCodesFilter(
 	override val desc: String? = null,
@@ -29,7 +30,7 @@ data class ServiceByHcPartyPatientTagCodesFilter(
 			(item.withEncryptionMetadata()?.let { searchKeyMatcher(healthcarePartyId, it) } == true) &&
 			(item.secretForeignKeys?.intersect(patientSecretForeignKeys.toSet())?.isNotEmpty() == true) &&
 			(item.tags.any { tagCodes[it.type]?.let { codes -> it.code in codes } == true }) &&
-			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { it >= startValueDate } == true) &&
-			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { it <= endValueDate } == true)
+			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true) &&
+			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true)
 		)
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientTagPrefixFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyPatientTagPrefixFilter.kt
@@ -8,6 +8,7 @@ import org.taktik.icure.domain.filter.service.ServiceByHcPartyPatientTagPrefixFi
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.embed.Service
 import org.taktik.icure.entities.embed.withEncryptionMetadata
+import org.taktik.icure.utils.FuzzyDates
 
 data class ServiceByHcPartyPatientTagPrefixFilter(
 	override val desc: String? = null,
@@ -30,7 +31,7 @@ data class ServiceByHcPartyPatientTagPrefixFilter(
 			(item.withEncryptionMetadata()?.let { searchKeyMatcher(healthcarePartyId, it) } == true) &&
 			(item.secretForeignKeys?.intersect(patientSecretForeignKeys.toSet())?.isNotEmpty() == true) &&
 			(item.tags.any { tagType == it.type && it.code?.startsWith(tagCodePrefix) == true }) &&
-			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { it >= startValueDate } == true) &&
-			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { it <= endValueDate } == true)
+			(startValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateAfterOrEqual(it, startValueDate) } == true) &&
+			(endValueDate == null || (item.valueDate ?: item.openingDate)?.let { FuzzyDates.isFuzzyDateBeforeOrEqual(it, endValueDate) } == true)
 		)
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyTagCodesFilter.kt
@@ -4,19 +4,18 @@
 package org.taktik.icure.domain.filter.impl.service
 
 import org.taktik.icure.domain.filter.AbstractFilter
-import org.taktik.icure.domain.filter.service.ServiceByHcPartyCodePrefixFilter
+import org.taktik.icure.domain.filter.service.ServiceByHcPartyTagCodesFilter
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.embed.Service
 
-data class ServiceByHcPartyCodePrefixFilter(
+data class ServiceByHcPartyTagCodesFilter(
 	override val desc: String? = null,
 	override val healthcarePartyId: String,
-	override val codeType: String,
-	override val codeCodePrefix: String,
+	override val tagCodes: Map<String, Collection<String>>,
 	override val startValueDate: Long? = null,
 	override val endValueDate: Long? = null,
 ) : AbstractFilter<Service>,
-	ServiceByHcPartyCodePrefixFilter {
+	ServiceByHcPartyTagCodesFilter {
 
 	override val canBeUsedInWebsocket = false
 	override val requiresSecurityPrecondition: Boolean = false

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyTagPrefixFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/impl/service/ServiceByHcPartyTagPrefixFilter.kt
@@ -13,6 +13,8 @@ data class ServiceByHcPartyTagPrefixFilter(
 	override val healthcarePartyId: String,
 	override val tagType: String,
 	override val tagCodePrefix: String,
+	override val startValueDate: Long? = null,
+	override val endValueDate: Long? = null,
 ) : AbstractFilter<Service>,
 	ServiceByHcPartyTagPrefixFilter {
 

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyCodesFilter.kt
@@ -7,12 +7,11 @@ import org.taktik.icure.domain.filter.Filter
 import org.taktik.icure.entities.embed.Service
 
 /**
- * Equivalent to [ServiceByHcPartyTagPrefixFilter] but searches for codes instead of tags.
+ * Equivalent to [ServiceByHcPartyCodePrefixFilter] but matches exact code codes instead of prefixes.
  */
-interface ServiceByHcPartyCodePrefixFilter : Filter<String, Service> {
+interface ServiceByHcPartyCodesFilter : Filter<String, Service> {
 	val healthcarePartyId: String
-	val codeType: String
-	val codeCodePrefix: String
+	val codeCodes: Map<String, Collection<String>>
 	val startValueDate: Long?
 	val endValueDate: Long?
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyPatientCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyPatientCodesFilter.kt
@@ -7,12 +7,12 @@ import org.taktik.icure.domain.filter.Filter
 import org.taktik.icure.entities.embed.Service
 
 /**
- * Equivalent to [ServiceByHcPartyTagPrefixFilter] but searches for codes instead of tags.
+ * Equivalent to [ServiceByHcPartyPatientCodePrefixFilter] but matches exact code codes instead of prefixes.
  */
-interface ServiceByHcPartyCodePrefixFilter : Filter<String, Service> {
+interface ServiceByHcPartyPatientCodesFilter : Filter<String, Service> {
 	val healthcarePartyId: String
-	val codeType: String
-	val codeCodePrefix: String
+	val patientSecretForeignKeys: Set<String>
+	val codeCodes: Map<String, Collection<String>>
 	val startValueDate: Long?
 	val endValueDate: Long?
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
@@ -7,12 +7,12 @@ import org.taktik.icure.domain.filter.Filter
 import org.taktik.icure.entities.embed.Service
 
 /**
- * Equivalent to [ServiceByHcPartyTagPrefixFilter] but searches for codes instead of tags.
+ * Equivalent to [ServiceByHcPartyPatientTagPrefixFilter] but matches exact tag codes instead of prefixes.
  */
-interface ServiceByHcPartyCodePrefixFilter : Filter<String, Service> {
+interface ServiceByHcPartyPatientTagCodesFilter : Filter<String, Service> {
 	val healthcarePartyId: String
-	val codeType: String
-	val codeCodePrefix: String
+	val patientSecretForeignKeys: Set<String>
+	val tagCodes: Map<String, Collection<String>>
 	val startValueDate: Long?
 	val endValueDate: Long?
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyTagCodesFilter.kt
@@ -7,12 +7,11 @@ import org.taktik.icure.domain.filter.Filter
 import org.taktik.icure.entities.embed.Service
 
 /**
- * Equivalent to [ServiceByHcPartyTagPrefixFilter] but searches for codes instead of tags.
+ * Equivalent to [ServiceByHcPartyTagPrefixFilter] but matches exact tag codes instead of prefixes.
  */
-interface ServiceByHcPartyCodePrefixFilter : Filter<String, Service> {
+interface ServiceByHcPartyTagCodesFilter : Filter<String, Service> {
 	val healthcarePartyId: String
-	val codeType: String
-	val codeCodePrefix: String
+	val tagCodes: Map<String, Collection<String>>
 	val startValueDate: Long?
 	val endValueDate: Long?
 }

--- a/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyTagPrefixFilter.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/domain/filter/service/ServiceByHcPartyTagPrefixFilter.kt
@@ -18,4 +18,6 @@ interface ServiceByHcPartyTagPrefixFilter : Filter<String, Service> {
 	val healthcarePartyId: String
 	val tagType: String
 	val tagCodePrefix: String
+	val startValueDate: Long?
+	val endValueDate: Long?
 }

--- a/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
@@ -298,4 +298,34 @@ object FuzzyDates {
 
 	// No precision encoding
 	fun getFuzzyTime(time: LocalTime) = time.hour * 1_00_00 + time.minute * 1_00 + time.second
+
+	private const val MAX_MONTHS = 24
+
+	/**
+	 * Returns a list of (year, month) pairs covering the range from [startValueDate] to [endValueDate],
+	 * or null if the range spans more than [MAX_MONTHS] months.
+	 * Value dates can be in YYYYMMDD (8 digits) or YYYYMMDDHHmmSS (14 digits) format.
+	 */
+	fun getMonthRange(startValueDate: Long, endValueDate: Long): List<Pair<Int, Int>>? {
+		val normalizedStart = if (startValueDate < 99999999) startValueDate * 1000000 else startValueDate
+		val normalizedEnd = if (endValueDate < 99999999) endValueDate * 1000000 else endValueDate
+		val startYear = (normalizedStart / 10000000000).toInt()
+		val startMonth = ((normalizedStart / 100000000) % 100).toInt()
+		val endYear = (normalizedEnd / 10000000000).toInt()
+		val endMonth = ((normalizedEnd / 100000000) % 100).toInt()
+		val totalMonths = (endYear - startYear) * 12 + (endMonth - startMonth) + 1
+		if (totalMonths !in 1..MAX_MONTHS) return null
+		return buildList {
+			var year = startYear
+			var month = startMonth
+			repeat(totalMonths) {
+				add(year to month)
+				month++
+				if (month > 12) {
+					month = 1
+					year++
+				}
+			}
+		}
+	}
 }

--- a/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
@@ -299,6 +299,32 @@ object FuzzyDates {
 	// No precision encoding
 	fun getFuzzyTime(time: LocalTime) = time.hour * 1_00_00 + time.minute * 1_00 + time.second
 
+	/**
+	 * Normalizes a fuzzy date to full datetime precision (YYYYMMDDHHmmss).
+	 * If the date is in YYYYMMDD format (8 digits), it is padded to 14 digits:
+	 * - with 000000 (start of day) when [endOfDay] is false
+	 * - with 235959 (end of day) when [endOfDay] is true
+	 * Dates already in YYYYMMDDHHmmss format are returned as-is.
+	 */
+	fun toFullFuzzyDateTime(date: Long, endOfDay: Boolean = false): Long =
+		if (date in MIN_FUZZY_DATE.toLong()..MAX_FUZZY_DATE.toLong())
+			date * 1000000 + (if (endOfDay) 235959 else 0)
+		else date
+
+	/**
+	 * Checks if [date] >= [reference], normalizing both to full datetime format.
+	 * Short dates (YYYYMMDD) are treated as start of day (000000).
+	 */
+	fun isFuzzyDateAfterOrEqual(date: Long, reference: Long): Boolean =
+		toFullFuzzyDateTime(date) >= toFullFuzzyDateTime(reference)
+
+	/**
+	 * Checks if [date] <= [reference], normalizing both to full datetime format.
+	 * A short [reference] (YYYYMMDD) is treated as end of day (235959) to be inclusive.
+	 */
+	fun isFuzzyDateBeforeOrEqual(date: Long, reference: Long): Boolean =
+		toFullFuzzyDateTime(date) <= toFullFuzzyDateTime(reference, endOfDay = true)
+
 	private const val MAX_MONTHS = 24
 
 	/**

--- a/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
@@ -333,25 +333,13 @@ object FuzzyDates {
 	 * Value dates can be in YYYYMMDD (8 digits) or YYYYMMDDHHmmSS (14 digits) format.
 	 */
 	fun getMonthRange(startValueDate: Long, endValueDate: Long): List<Pair<Int, Int>>? {
-		val normalizedStart = if (startValueDate < 99999999) startValueDate * 1000000 else startValueDate
-		val normalizedEnd = if (endValueDate < 99999999) endValueDate * 1000000 else endValueDate
-		val startYear = (normalizedStart / 10000000000).toInt()
-		val startMonth = ((normalizedStart / 100000000) % 100).toInt()
-		val endYear = (normalizedEnd / 10000000000).toInt()
-		val endMonth = ((normalizedEnd / 100000000) % 100).toInt()
-		val totalMonths = (endYear - startYear) * 12 + (endMonth - startMonth) + 1
+		val startDateTime = getFullLocalDateTime(toFullFuzzyDateTime(startValueDate), lenient = true) ?: return null
+		val endDateTime = getFullLocalDateTime(toFullFuzzyDateTime(endValueDate), lenient = true) ?: return null
+		val totalMonths = ((endDateTime.year - startDateTime.year) * 12 + (endDateTime.monthValue - startDateTime.monthValue)) + 1
 		if (totalMonths !in 1..MAX_MONTHS) return null
-		return buildList {
-			var year = startYear
-			var month = startMonth
-			repeat(totalMonths) {
-				add(year to month)
-				month++
-				if (month > 12) {
-					month = 1
-					year++
-				}
-			}
+		return (0 until totalMonths).map { i ->
+			val date = startDateTime.plusMonths(i.toLong())
+			date.year to date.monthValue
 		}
 	}
 }

--- a/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/utils/FuzzyDates.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 
@@ -325,21 +326,29 @@ object FuzzyDates {
 	fun isFuzzyDateBeforeOrEqual(date: Long, reference: Long): Boolean =
 		toFullFuzzyDateTime(date) <= toFullFuzzyDateTime(reference, endOfDay = true)
 
-	private const val MAX_MONTHS = 24
-
 	/**
 	 * Returns a list of (year, month) pairs covering the range from [startValueDate] to [endValueDate],
-	 * or null if the range spans more than [MAX_MONTHS] months.
+	 * or null if the range spans more than [maxMonths] months.
 	 * Value dates can be in YYYYMMDD (8 digits) or YYYYMMDDHHmmSS (14 digits) format.
 	 */
-	fun getMonthRange(startValueDate: Long, endValueDate: Long): List<Pair<Int, Int>>? {
+	fun getMonthRange(startValueDate: Long, endValueDate: Long, maxMonths: Int): List<Pair<Int, Int>>? {
 		val startDateTime = getFullLocalDateTime(toFullFuzzyDateTime(startValueDate), lenient = true) ?: return null
 		val endDateTime = getFullLocalDateTime(toFullFuzzyDateTime(endValueDate), lenient = true) ?: return null
 		val totalMonths = ((endDateTime.year - startDateTime.year) * 12 + (endDateTime.monthValue - startDateTime.monthValue)) + 1
-		if (totalMonths !in 1..MAX_MONTHS) return null
+		if (totalMonths !in 1..maxMonths) return null
 		return (0 until totalMonths).map { i ->
 			val date = startDateTime.plusMonths(i.toLong())
 			date.year to date.monthValue
 		}
 	}
+
+
+	/**
+	 * Get the highest possible value for now in all time zones of the world
+	 */
+	fun maxPossibleFuzzyNowInAllTimeZones(): Long = FuzzyDates.getFuzzyDateTime(
+		LocalDateTime.now(ZoneId.ofOffset("UTC", ZoneOffset.ofHours(14))),
+		ChronoUnit.SECONDS, false
+	)
+
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyCodePrefixFilter.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyCodePrefixFilter.kt
@@ -27,4 +27,8 @@ data class ServiceByHcPartyCodePrefixFilter(
 	val codeCodePrefix: String,
 	/** Optional description of this filter. */
 	override val desc: String? = null,
-) : AbstractFilterDto<ServiceDto>
+	/** Optional start of a range of date for the value date of the service */
+	val startValueDate: Long? = null,
+	/** Optional end of a range of date for the value date of the service */
+	val endValueDate: Long? = null,
+	) : AbstractFilterDto<ServiceDto>

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyCodesFilter.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyCodesFilter.kt
@@ -15,20 +15,10 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
 @JsonDeserialize(using = JsonDeserializer.None::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-/**
- * Filter that matches services by healthcare party and tag prefix.
- */
-data class ServiceByHcPartyTagPrefixFilter(
-	/** The identifier of the healthcare party. */
+data class ServiceByHcPartyCodesFilter(
 	val healthcarePartyId: String,
-	/** The type of the tag to match. */
-	val tagType: String,
-	/** The tag code prefix to match. */
-	val tagCodePrefix: String,
-	/** Optional description of this filter. */
-	override val desc: String? = null,
-	/** Optional start of a range of date for the value date of the service */
+	val codeCodes: Map<String, Collection<String>>,
 	val startValueDate: Long? = null,
-	/** Optional end of a range of date for the value date of the service */
 	val endValueDate: Long? = null,
+	override val desc: String? = null,
 ) : AbstractFilterDto<ServiceDto>

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyPatientCodesFilter.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyPatientCodesFilter.kt
@@ -15,20 +15,11 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
 @JsonDeserialize(using = JsonDeserializer.None::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-/**
- * Filter that matches services by healthcare party and tag prefix.
- */
-data class ServiceByHcPartyTagPrefixFilter(
-	/** The identifier of the healthcare party. */
+data class ServiceByHcPartyPatientCodesFilter(
 	val healthcarePartyId: String,
-	/** The type of the tag to match. */
-	val tagType: String,
-	/** The tag code prefix to match. */
-	val tagCodePrefix: String,
-	/** Optional description of this filter. */
-	override val desc: String? = null,
-	/** Optional start of a range of date for the value date of the service */
+	val patientSecretForeignKeys: Set<String>,
+	val codeCodes: Map<String, Collection<String>>,
 	val startValueDate: Long? = null,
-	/** Optional end of a range of date for the value date of the service */
 	val endValueDate: Long? = null,
+	override val desc: String? = null,
 ) : AbstractFilterDto<ServiceDto>

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyPatientTagCodesFilter.kt
@@ -15,20 +15,11 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
 @JsonDeserialize(using = JsonDeserializer.None::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-/**
- * Filter that matches services by healthcare party and tag prefix.
- */
-data class ServiceByHcPartyTagPrefixFilter(
-	/** The identifier of the healthcare party. */
+data class ServiceByHcPartyPatientTagCodesFilter(
 	val healthcarePartyId: String,
-	/** The type of the tag to match. */
-	val tagType: String,
-	/** The tag code prefix to match. */
-	val tagCodePrefix: String,
-	/** Optional description of this filter. */
-	override val desc: String? = null,
-	/** Optional start of a range of date for the value date of the service */
+	val patientSecretForeignKeys: Set<String>,
+	val tagCodes: Map<String, Collection<String>>,
 	val startValueDate: Long? = null,
-	/** Optional end of a range of date for the value date of the service */
 	val endValueDate: Long? = null,
+	override val desc: String? = null,
 ) : AbstractFilterDto<ServiceDto>

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyTagCodesFilter.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/filter/service/ServiceByHcPartyTagCodesFilter.kt
@@ -15,20 +15,10 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.AbstractFilterDto
 @JsonDeserialize(using = JsonDeserializer.None::class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-/**
- * Filter that matches services by healthcare party and tag prefix.
- */
-data class ServiceByHcPartyTagPrefixFilter(
-	/** The identifier of the healthcare party. */
+data class ServiceByHcPartyTagCodesFilter(
 	val healthcarePartyId: String,
-	/** The type of the tag to match. */
-	val tagType: String,
-	/** The tag code prefix to match. */
-	val tagCodePrefix: String,
-	/** Optional description of this filter. */
-	override val desc: String? = null,
-	/** Optional start of a range of date for the value date of the service */
+	val tagCodes: Map<String, Collection<String>>,
 	val startValueDate: Long? = null,
-	/** Optional end of a range of date for the value date of the service */
 	val endValueDate: Long? = null,
+	override val desc: String? = null,
 ) : AbstractFilterDto<ServiceDto>

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/filter/FilterMapper.kt
@@ -179,14 +179,18 @@ import org.taktik.icure.services.external.rest.v2.dto.filter.pricing.PricingByRe
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByAssociationIdFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByDataOwnerPatientDateFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyCodePrefixFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyCodesFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyHealthElementIdsFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyIdentifiersFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyMonthCodePrefixFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyMonthTagPrefixFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyPatientCodePrefixFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyPatientCodesFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyPatientTagCodesFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyPatientTagPrefixFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyTagCodeDateFilter
+import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyTagCodesFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByHcPartyTagPrefixFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByIdsFilter
 import org.taktik.icure.services.external.rest.v2.dto.filter.service.ServiceByQualifiedLinkFilter
@@ -483,6 +487,10 @@ abstract class FilterV2Mapper {
 	abstract fun map(filterDto: ServiceByHcPartyPatientTagPrefixFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyPatientTagPrefixFilter
 	abstract fun map(filterDto: ServiceByHcPartyCodePrefixFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyCodePrefixFilter
 	abstract fun map(filterDto: ServiceByHcPartyTagPrefixFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyTagPrefixFilter
+	abstract fun map(filterDto: ServiceByHcPartyCodesFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyCodesFilter
+	abstract fun map(filterDto: ServiceByHcPartyTagCodesFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyTagCodesFilter
+	abstract fun map(filterDto: ServiceByHcPartyPatientCodesFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyPatientCodesFilter
+	abstract fun map(filterDto: ServiceByHcPartyPatientTagCodesFilter): org.taktik.icure.domain.filter.impl.service.ServiceByHcPartyPatientTagCodesFilter
 
 	@Suppress("DEPRECATION")
 	@JvmName("tryMapServiceFilter")
@@ -503,6 +511,10 @@ abstract class FilterV2Mapper {
 		is ServiceByHcPartyPatientTagPrefixFilter -> map(filterDto)
 		is ServiceByHcPartyTagPrefixFilter -> map(filterDto)
 		is ServiceByHcPartyCodePrefixFilter -> map(filterDto)
+		is ServiceByHcPartyCodesFilter -> map(filterDto)
+		is ServiceByHcPartyTagCodesFilter -> map(filterDto)
+		is ServiceByHcPartyPatientCodesFilter -> map(filterDto)
+		is ServiceByHcPartyPatientTagCodesFilter -> map(filterDto)
 		else -> mapGeneralFilterToDomain(filterDto) { tryMap(it) }
 	}
 


### PR DESCRIPTION
Jira: [ICBE-384](https://icure.atlassian.net/browse/ICBE-384)

## Summary
- Add 4 new service filters for exact code/tag matching: `ServiceByHcPartyCodesFilter`, `ServiceByHcPartyTagCodesFilter`, `ServiceByHcPartyPatientCodesFilter`, `ServiceByHcPartyPatientTagCodesFilter`
- New filters accept `Map<String, Collection<String>>` (type → codes) enabling multi-type queries in a single filter call
- Add `startValueDate`/`endValueDate` support to existing prefix filters (`ServiceByHcPartyCodePrefixFilter`, `ServiceByHcPartyTagPrefixFilter`)
- Update CouchDB views (`Service_by_data_owner_code_prefix.js`, `Service_by_data_owner_tag_prefix.js`) to emit `[serviceId, date]` tuples for date-based filtering
- Add month-range optimization for date-bounded queries via `FuzzyDates.getMonthRange`
- Add new DAO methods for exact code/tag matching with date filtering

## Test plan
- [ ] Integration tests in kraken-cloud ServiceFilterTest covering all new and modified filters
- [ ] Verify prefix filters still match multiple codes (e.g., prefix "TAG" matches "TAG" and "TAGX")
- [ ] Verify exact-match filters only match specified codes
- [ ] Verify multi-type map queries return correct union of results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ICBE-384]: https://icure.atlassian.net/browse/ICBE-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ