### PR TITLE
Object storage support for receipts

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/AttachmentManagementDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/AttachmentManagementDAOImpl.kt
@@ -14,6 +14,7 @@ import org.taktik.icure.datastore.IDatastoreInformation
 import org.taktik.icure.entities.base.StoredDocument
 import java.nio.ByteBuffer
 
+// TODO should use this one at some point instead of reimplementing the logic everywhere (on document dao, on receipt dao, ...)
 abstract class AttachmentManagementDAOImpl<T : StoredDocument>(
 	protected val entityClass: Class<T>,
 	protected val couchDbDispatcher: CouchDbDispatcher,

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/AttachmentManagementDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/AttachmentManagementDAOImpl.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import org.taktik.icure.asyncdao.AttachmentManagementDAO
 import org.taktik.icure.asyncdao.CouchDbDispatcher
+import org.taktik.icure.cache.EntityCacheChainLink
 import org.taktik.icure.datastore.IDatastoreInformation
 import org.taktik.icure.entities.base.StoredDocument
 import java.nio.ByteBuffer
@@ -16,6 +17,7 @@ import java.nio.ByteBuffer
 abstract class AttachmentManagementDAOImpl<T : StoredDocument>(
 	protected val entityClass: Class<T>,
 	protected val couchDbDispatcher: CouchDbDispatcher,
+	private val cacheChain: EntityCacheChainLink<String, T>?
 ) : AttachmentManagementDAO<T> {
 	override fun getAttachment(
 		datastoreInformation: IDatastoreInformation,
@@ -36,7 +38,9 @@ abstract class AttachmentManagementDAOImpl<T : StoredDocument>(
 		data: Flow<ByteBuffer>,
 	): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.createAttachment(documentId, attachmentId, rev, contentType, data)
+		return client.createAttachment(documentId, attachmentId, rev, contentType, data).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	override suspend fun deleteAttachment(
@@ -46,6 +50,8 @@ abstract class AttachmentManagementDAOImpl<T : StoredDocument>(
 		attachmentId: String,
 	): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.deleteAttachment(documentId, attachmentId, rev)
+		return client.deleteAttachment(documentId, attachmentId, rev).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/DocumentDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/DocumentDAOImpl.kt
@@ -258,7 +258,9 @@ class DocumentDAOImpl(
 		data: Flow<ByteBuffer>,
 	): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.createAttachment(documentId, attachmentId, rev, contentType, data)
+		return client.createAttachment(documentId, attachmentId, rev, contentType, data).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	override suspend fun deleteAttachment(
@@ -268,7 +270,9 @@ class DocumentDAOImpl(
 		attachmentId: String,
 	): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.deleteAttachment(documentId, attachmentId, rev)
+		return client.deleteAttachment(documentId, attachmentId, rev).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	@View(

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/DocumentTemplateDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/DocumentTemplateDAOImpl.kt
@@ -309,7 +309,9 @@ class DocumentTemplateDAOImpl(
 		data: Flow<ByteBuffer>,
 	): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.createAttachment(documentId, attachmentId, rev, contentType, data)
+		return client.createAttachment(documentId, attachmentId, rev, contentType, data).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	override suspend fun deleteAttachment(
@@ -319,6 +321,8 @@ class DocumentTemplateDAOImpl(
 		attachmentId: String,
 	): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.deleteAttachment(documentId, attachmentId, rev)
+		return client.deleteAttachment(documentId, attachmentId, rev).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/FormTemplateDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/FormTemplateDAOImpl.kt
@@ -238,12 +238,16 @@ internal class FormTemplateDAOImpl(
 
 	override suspend fun createAttachment(datastoreInformation: IDatastoreInformation, documentId: String, attachmentId: String, rev: String, contentType: String, data: Flow<ByteBuffer>): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.createAttachment(documentId, attachmentId, rev, contentType, data)
+		return client.createAttachment(documentId, attachmentId, rev, contentType, data).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	override suspend fun deleteAttachment(datastoreInformation: IDatastoreInformation, documentId: String, rev: String, attachmentId: String): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.deleteAttachment(documentId, attachmentId, rev)
+		return client.deleteAttachment(documentId, attachmentId, rev).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	companion object {

--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ReceiptDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ReceiptDAOImpl.kt
@@ -69,12 +69,16 @@ class ReceiptDAOImpl(
 
 	override suspend fun createAttachment(datastoreInformation: IDatastoreInformation, documentId: String, attachmentId: String, rev: String, contentType: String, data: Flow<ByteBuffer>): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.createAttachment(documentId, attachmentId, rev, contentType, data)
+		return client.createAttachment(documentId, attachmentId, rev, contentType, data).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	override suspend fun deleteAttachment(datastoreInformation: IDatastoreInformation, documentId: String, rev: String, attachmentId: String): String {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		return client.deleteAttachment(documentId, attachmentId, rev)
+		return client.deleteAttachment(documentId, attachmentId, rev).also {
+			cacheChain?.evictFromCache(datastoreInformation.getFullIdFor(documentId))
+		}
 	}
 
 	@View(

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
@@ -111,6 +111,10 @@ open class ReceiptLogicImpl(
 		if (storedDataSize > HARD_LIMIT_ATTACHMENT) throw ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE, "Attachment size exceeds limit of $HARD_LIMIT_ATTACHMENT bytes")
 		val payload = data.enforceSize(storedDataSize).toByteArray(true)
 		val newAttachmentId = DigestUtils.sha256Hex(payload)
+		val currentReceipt = receiptDAO.get(datastoreInformation, receiptId) ?: throw NotFoundRequestException("Receipt with id $receiptId not found")
+		if (currentReceipt.attachmentIds.containsKey(blobType) || currentReceipt.attachmentInfos.containsKey(blobType)) {
+			throw IllegalArgumentException("Another attachment for blob type $blobType already exists in receipt $receiptId")
+		}
 		receiptDAO.createAttachment(
 			datastoreInformation,
 			receiptId,
@@ -120,9 +124,6 @@ open class ReceiptLogicImpl(
 			flowOf(ByteBuffer.wrap(payload)),
 		)
 		val receipt = receiptDAO.get(datastoreInformation, receiptId) ?: throw NotFoundRequestException("Receipt with id $receiptId not found")
-		if (receipt.attachmentIds.containsKey(blobType) || receipt.attachmentInfos.containsKey(blobType)) {
-			throw IllegalArgumentException("Another attachment for blob type $blobType already exists in receipt $receiptId")
-		}
 		val updatedAttachmentInfo = receipt.attachmentInfos + Pair(
 			blobType,
 			DataAttachment(

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
@@ -120,12 +120,9 @@ open class ReceiptLogicImpl(
 			flowOf(ByteBuffer.wrap(payload)),
 		)
 		val receipt = receiptDAO.get(datastoreInformation, receiptId) ?: throw NotFoundRequestException("Receipt with id $receiptId not found")
-		val updatedAttachments = receipt.attachments?.let { attachments ->
-			receipt.attachmentIds[blobType]?.let { prevAttachmentForBlobType ->
-				attachments - prevAttachmentForBlobType
-			} ?: attachments
+		if (receipt.attachmentIds.containsKey(blobType) || receipt.attachmentInfos.containsKey(blobType)) {
+			throw IllegalArgumentException("Another attachment for blob type $blobType already exists in receipt $receiptId")
 		}
-		val updatedAttachmentIds = receipt.attachmentIds - blobType
 		val updatedAttachmentInfo = receipt.attachmentInfos + Pair(
 			blobType,
 			DataAttachment(
@@ -138,13 +135,7 @@ open class ReceiptLogicImpl(
 				realDataSize = realDataSize,
 			)
 		)
-		return modifyEntity(
-			receipt.copy(
-				attachments = updatedAttachments,
-				attachmentIds = updatedAttachmentIds,
-				attachmentInfos = updatedAttachmentInfo,
-			)
-		)
+		return modifyEntity(receipt.copy(attachmentInfos = updatedAttachmentInfo))
 	}
 
 	override fun getDataAttachmentByBlobType(

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
@@ -9,7 +9,14 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import org.apache.commons.codec.digest.DigestUtils
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.PayloadTooLargeException
+import org.springframework.web.server.ResponseStatusException
 import org.taktik.icure.asyncdao.ReceiptDAO
 import org.taktik.icure.asynclogic.ConflictResolutionLogic
 import org.taktik.icure.asynclogic.ExchangeDataMapLogic
@@ -17,13 +24,22 @@ import org.taktik.icure.asynclogic.ReceiptLogic
 import org.taktik.icure.asynclogic.SessionInformationProvider
 import org.taktik.icure.asynclogic.base.impl.EntityWithEncryptionMetadataLogic
 import org.taktik.icure.asynclogic.impl.filter.Filters
+import org.taktik.icure.asynclogic.objectstorage.ReceiptDataAttachmentLoader
+import org.taktik.icure.asynclogic.objectstorage.contentFlowOfNullable
 import org.taktik.icure.datastore.DatastoreInstanceProvider
 import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.embed.ReceiptBlobType
 import org.taktik.icure.entities.embed.SecurityMetadata
+import org.taktik.icure.entities.objectstorage.DataAttachment
+import org.taktik.icure.exceptions.ConflictRequestException
+import org.taktik.icure.exceptions.NotFoundRequestException
 import org.taktik.icure.mergers.Merger
+import org.taktik.icure.utils.enforceSize
+import org.taktik.icure.utils.toByteArray
 import org.taktik.icure.validation.aspect.Fixer
 import java.nio.ByteBuffer
+
+private const val HARD_LIMIT_ATTACHMENT = 4 * 1024 * 1024 // 4 MB
 
 open class ReceiptLogicImpl(
 	private val receiptDAO: ReceiptDAO,
@@ -33,6 +49,7 @@ open class ReceiptLogicImpl(
 	fixer: Fixer,
 	filters: Filters,
 	merger: Merger<Receipt>,
+	@param:Qualifier("receiptDataAttachmentLoader") private val attachmentLoader: ReceiptDataAttachmentLoader,
 ) : EntityWithEncryptionMetadataLogic<Receipt, ReceiptDAO>(fixer, sessionLogic, datastoreInstanceProvider, exchangeDataMapLogic, filters),
 	ConflictResolutionLogic<Receipt> by ConflictResolutionLogicImpl(receiptDAO, merger, datastoreInstanceProvider),
 	ReceiptLogic {
@@ -61,6 +78,7 @@ open class ReceiptLogicImpl(
 		blobType: ReceiptBlobType,
 		payload: ByteArray,
 	): Receipt {
+		// TODO add hard limit after some time since we implemented client-side compression
 		val datastoreInformation = getInstanceAndGroup()
 		val newAttachmentId = DigestUtils.sha256Hex(payload)
 		val modifiedReceipt = modifyEntities(listOf(receipt.copy(attachmentIds = receipt.attachmentIds + (blobType to newAttachmentId)))).first()
@@ -75,6 +93,72 @@ open class ReceiptLogicImpl(
 				contentType,
 				flowOf(ByteBuffer.wrap(payload)),
 			),
+		)
+	}
+
+	override suspend fun putReceiptAttachmentInfo(
+		receiptId: String,
+		receiptRev: String,
+		blobType: ReceiptBlobType,
+		compressionAlgorithm: String?,
+		triedCompressionAlgorithmsVersion: String?,
+		realDataSize: Long?,
+		storedDataSize: Long,
+		data: Flow<DataBuffer>
+	): Receipt {
+		// TODO replace hard limit with actual streaming of data to couchdb (problem: we can't now attachment id beforehand)
+		val datastoreInformation = getInstanceAndGroup()
+		if (storedDataSize > HARD_LIMIT_ATTACHMENT) throw ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE, "Attachment size exceeds limit of $HARD_LIMIT_ATTACHMENT bytes")
+		val payload = data.enforceSize(storedDataSize).toByteArray(true)
+		val newAttachmentId = DigestUtils.sha256Hex(payload)
+		receiptDAO.createAttachment(
+			datastoreInformation,
+			receiptId,
+			newAttachmentId,
+			receiptRev,
+			"application/octet-stream",
+			flowOf(ByteBuffer.wrap(payload)),
+		)
+		val receipt = receiptDAO.get(datastoreInformation, receiptId) ?: throw NotFoundRequestException("Receipt with id $receiptId not found")
+		val updatedAttachments = receipt.attachments?.let { attachments ->
+			receipt.attachmentIds[blobType]?.let { prevAttachmentForBlobType ->
+				attachments - prevAttachmentForBlobType
+			} ?: attachments
+		}
+		val updatedAttachmentIds = receipt.attachmentIds - blobType
+		val updatedAttachmentInfo = receipt.attachmentInfos + Pair(
+			blobType,
+			DataAttachment(
+				couchDbAttachmentId = newAttachmentId,
+				objectStoreAttachmentId = null,
+				utis = emptyList(),
+				compressionAlgorithm = compressionAlgorithm,
+				triedCompressionAlgorithmsVersion = triedCompressionAlgorithmsVersion,
+				storedDataSize = storedDataSize,
+				realDataSize = realDataSize,
+			)
+		)
+		return modifyEntity(
+			receipt.copy(
+				attachments = updatedAttachments,
+				attachmentIds = updatedAttachmentIds,
+				attachmentInfos = updatedAttachmentInfo,
+			)
+		)
+	}
+
+	override fun getDataAttachmentByBlobType(
+		receiptId: String,
+		blobType: ReceiptBlobType
+	): Flow<DataBuffer> = flow {
+		val datastoreInformation = getInstanceAndGroup()
+		val receipt = receiptDAO.get(datastoreInformation, receiptId) ?: throw NotFoundRequestException("Receipt with id $receiptId not found")
+		emitAll(
+			receipt.attachmentIds[blobType]?.let { attachmentId ->
+				getAttachment(receiptId, attachmentId)
+			}?.map { DefaultDataBufferFactory.sharedInstance.wrap(it) }
+				?: attachmentLoader.contentFlowOfNullable(receipt) { attachmentInfos[blobType] }
+				?: throw NotFoundRequestException("No attachment for blob type $blobType in receipt $receiptId")
 		)
 	}
 

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/ObjectStorageEntityGroupName.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/ObjectStorageEntityGroupName.kt
@@ -1,0 +1,10 @@
+package org.taktik.icure.asynclogic.objectstorage
+
+/**
+ * Name of groups of entities with data attachments, to allow grouping stored attachments by type of entity which owns the attachment.
+ */
+@Suppress("EnumEntryName")
+enum class ObjectStorageEntityGroupName {
+	receipts,
+	documents
+}

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/DataAttachmentLoaderImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/DataAttachmentLoaderImpl.kt
@@ -12,18 +12,22 @@ import org.springframework.stereotype.Service
 import org.taktik.couchdb.exception.CouchDbException
 import org.taktik.icure.asyncdao.AttachmentManagementDAO
 import org.taktik.icure.asyncdao.DocumentDAO
+import org.taktik.icure.asyncdao.ReceiptDAO
 import org.taktik.icure.asynclogic.objectstorage.DataAttachmentLoader
 import org.taktik.icure.asynclogic.objectstorage.DocumentDataAttachmentLoader
 import org.taktik.icure.asynclogic.objectstorage.DocumentObjectStorage
 import org.taktik.icure.asynclogic.objectstorage.DocumentObjectStorageMigration
 import org.taktik.icure.asynclogic.objectstorage.IcureObjectStorage
 import org.taktik.icure.asynclogic.objectstorage.IcureObjectStorageMigration
+import org.taktik.icure.asynclogic.objectstorage.ReceiptDataAttachmentLoader
+import org.taktik.icure.asynclogic.objectstorage.ReceiptObjectStorage
+import org.taktik.icure.asynclogic.objectstorage.ReceiptObjectStorageMigration
 import org.taktik.icure.asynclogic.objectstorage.contentBytesOfNullable
 import org.taktik.icure.entities.Document
+import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.base.HasDataAttachments
 import org.taktik.icure.entities.objectstorage.DataAttachment
 import org.taktik.icure.exceptions.IllegalEntityException
-import org.taktik.icure.exceptions.NotFoundRequestException
 import org.taktik.icure.properties.ObjectStorageProperties
 import org.taktik.icure.security.CryptoUtils
 import org.taktik.icure.security.CryptoUtils.isValidAesKey
@@ -38,6 +42,7 @@ class DataAttachmentLoaderImpl<T : HasDataAttachments<T>>(
 	private val icureObjectStorageMigration: IcureObjectStorageMigration<T>,
 	private val objectStorageProperties: ObjectStorageProperties,
 	private val datastoreInstanceProvider: org.taktik.icure.datastore.DatastoreInstanceProvider,
+	private val overrideShouldMigrate: Boolean?
 ) : DataAttachmentLoader<T> {
 	private val migrationSizeLimit get() =
 		objectStorageProperties.migrationSizeLimit.coerceAtLeast(objectStorageProperties.sizeLimit)
@@ -96,12 +101,32 @@ class DataAttachmentLoaderImpl<T : HasDataAttachments<T>>(
 	private fun shouldMigrate(
 		target: T,
 		attachmentId: String,
-	) = objectStorageProperties.backlogToObjectStorage &&
-		target.attachments
-			?.get(attachmentId)
-			?.length
-			?.let { it >= migrationSizeLimit } == true
+	) = overrideShouldMigrate ?: (
+		objectStorageProperties.backlogToObjectStorage &&
+			target.attachments
+				?.get(attachmentId)
+				?.length
+				?.let { it >= migrationSizeLimit } == true
+		)
 }
+
+@Service("receiptDataAttachmentLoader")
+@Profile("app")
+class ReceiptDataAttachmentLoaderImpl(
+	dao: ReceiptDAO,
+	objectStorage: ReceiptObjectStorage,
+	objectStorageMigration: ReceiptObjectStorageMigration,
+	objectStorageProperties: ObjectStorageProperties,
+	datastoreInstanceProvider: org.taktik.icure.datastore.DatastoreInstanceProvider,
+) : ReceiptDataAttachmentLoader,
+	DataAttachmentLoader<Receipt> by DataAttachmentLoaderImpl(
+		dao,
+		objectStorage,
+		objectStorageMigration,
+		objectStorageProperties,
+		datastoreInstanceProvider,
+		false
+	)
 
 @Service("documentDataAttachmentLoader")
 @Profile("app")
@@ -118,6 +143,7 @@ class DocumentDataAttachmentLoaderImpl(
 		objectStorageMigration,
 		objectStorageProperties,
 		datastoreInstanceProvider,
+		null
 	) {
 	override suspend fun decryptAttachment(
 		document: Document?,

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/DataAttachmentModificationLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/impl/DataAttachmentModificationLogicImpl.kt
@@ -48,7 +48,7 @@ abstract class DataAttachmentModificationLogicImpl<T : HasDataAttachments<T>>(
 			.withDataAttachments(
 				(currentAttachments.keys + newAttachments.keys)
 					.mapNotNull { key ->
-						ensureNoContentChange(currentAttachments[key], newAttachments[key], key !in lenientKeys, key)
+						validateOneChange(currentAttachments[key], newAttachments[key], key !in lenientKeys, key)
 							?.let { key to it }
 					}.toMap(),
 			).also {
@@ -58,20 +58,30 @@ abstract class DataAttachmentModificationLogicImpl<T : HasDataAttachments<T>>(
 			}
 	}
 
-	private fun ensureNoContentChange(
+	private fun validateOneChange(
 		currentAttachment: DataAttachment?,
 		updatedAttachment: DataAttachment?,
 		strict: Boolean,
 		attachmentKey: String,
 	): DataAttachment? = if (currentAttachment != null) {
-		if (updatedAttachment != null && updatedAttachment hasSameIdsAs currentAttachment) {
-			updatedAttachment
+		if (
+			updatedAttachment != null
+			&& updatedAttachment.couchDbAttachmentId == currentAttachment.couchDbAttachmentId
+			&& updatedAttachment.objectStoreAttachmentId == currentAttachment.objectStoreAttachmentId
+			&& updatedAttachment.realDataSize == currentAttachment.realDataSize
+			&& updatedAttachment.compressionAlgorithm == currentAttachment.compressionAlgorithm
+			&& (updatedAttachment.storedDataSize == null || updatedAttachment.storedDataSize == currentAttachment.storedDataSize)
+		) {
+			updatedAttachment.copy(storedDataSize = currentAttachment.storedDataSize)
 		} else {
 			require(!strict) {
-				"Inconsistency between updated and current for attachment $attachmentKey: " +
-					"expected ${currentAttachment.ids} but got ${updatedAttachment?.ids}"
+				"Inconsistency between updated and current for attachment $attachmentKey"
 			}
-			updatedAttachment?.withIdsOf(currentAttachment) ?: currentAttachment
+			updatedAttachment?.copy(
+				couchDbAttachmentId = currentAttachment.couchDbAttachmentId,
+				objectStoreAttachmentId = currentAttachment.objectStoreAttachmentId,
+				storedDataSize = currentAttachment.storedDataSize,
+			) ?: currentAttachment
 		}
 	} else {
 		require(!strict || updatedAttachment == null) {
@@ -219,7 +229,15 @@ abstract class DataAttachmentModificationLogicImpl<T : HasDataAttachments<T>>(
 				"Duplicate attachment content for ${entity::class.java.simpleName} ${entity.id}: $attachmentId",
 			)
 		}
-		DataAttachment(couchDbAttachmentId = attachmentId, objectStoreAttachmentId = null, utis = utis).let { dataAttachment ->
+		DataAttachment(
+			couchDbAttachmentId = attachmentId,
+			objectStoreAttachmentId = null,
+			utis = utis,
+			realDataSize = change.realDataSize,
+			triedCompressionAlgorithmsVersion = change.triedCompressionAlgorithmsVersion,
+			compressionAlgorithm = change.compressionAlgorithm,
+			storedDataSize = change.size
+		).let { dataAttachment ->
 			Pair(
 				dataAttachment,
 				if (entity.attachments?.keys?.contains(attachmentId) == true) {
@@ -240,7 +258,15 @@ abstract class DataAttachmentModificationLogicImpl<T : HasDataAttachments<T>>(
 		// we will duplicate the attachment on object storage, but it can be cleaned up by the periodic cleanup task.
 		val attachmentId = UUID.randomUUID().toString()
 		Pair(
-			DataAttachment(couchDbAttachmentId = null, objectStoreAttachmentId = attachmentId, utis = utis),
+			DataAttachment(
+				couchDbAttachmentId = null,
+				objectStoreAttachmentId = attachmentId,
+				utis = utis,
+				realDataSize = change.realDataSize,
+				triedCompressionAlgorithmsVersion = change.triedCompressionAlgorithmsVersion,
+				compressionAlgorithm = change.compressionAlgorithm,
+				storedDataSize = change.size
+			),
 			AttachmentTask.PreStoreAndUploadObjectStorage(
 				attachmentId,
 				change.data,

--- a/core/src/main/kotlin/org/taktik/icure/config/SharedWebConfig.kt
+++ b/core/src/main/kotlin/org/taktik/icure/config/SharedWebConfig.kt
@@ -25,9 +25,11 @@ import org.springframework.web.reactive.socket.server.WebSocketService
 import org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService
 import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter
 import org.springframework.web.reactive.socket.server.upgrade.ReactorNettyRequestUpgradeStrategy
+import org.taktik.icure.entities.utils.SemanticVersion
 import org.taktik.icure.services.external.http.WebSocketOperationHandler
 import org.taktik.icure.spring.encoder.FluxStringJsonEncoder
 import reactor.netty.http.server.WebsocketServerSpec
+import java.util.TreeMap
 
 @Configuration
 class SharedWebConfig {
@@ -52,6 +54,12 @@ class SharedWebConfig {
 }
 
 abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
+	interface CardinalMappers {
+		val byMinVersion: TreeMap<SemanticVersion, ObjectMapper>
+
+		fun getForVersion(semanticVersion: SemanticVersion): ObjectMapper? = byMinVersion.floorEntry(semanticVersion)?.value
+	}
+
 	private val CLASSPATH_RESOURCE_LOCATIONS =
 		arrayOf("classpath:/META-INF/resources/", "classpath:/resources/", "classpath:/static/", "classpath:/public/")
 
@@ -70,10 +78,13 @@ abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
 			.allowedHeaders("*")
 	}
 
+	// TODO may want to set a default filter instead of putting all explicitly at least for the legacy
 	private val legacyJacksonFilter: FilterProvider = SimpleFilterProvider()
 		.addFilter("healthElementFilter", SimpleBeanPropertyFilter.serializeAll())
 		.addFilter("userFilter", SimpleBeanPropertyFilter.serializeAll())
 		.addFilter("codeStubFilter", SimpleBeanPropertyFilter.serializeAll())
+		.addFilter("dataAttachmentFilter", SimpleBeanPropertyFilter.serializeAll())
+		.addFilter("documentFilter", SimpleBeanPropertyFilter.serializeAll())
 
 	protected val legacyObjectMapper: ObjectMapper =
 		ObjectMapper().registerModule(
@@ -81,30 +92,62 @@ abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
 				.configure(KotlinFeature.NullIsSameAsDefault, true)
 				.build()
 		).apply {
-			setSerializationInclusion(JsonInclude.Include.NON_NULL)
+			setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
 			setFilterProvider(legacyJacksonFilter)
 		}
 
 	@Bean
 	open fun legacyObjectMapper() = legacyObjectMapper
 
-	private val cardinalJacksonFilter: FilterProvider = SimpleFilterProvider()
-		.addFilter("healthElementFilter", SimpleBeanPropertyFilter.serializeAllExcept("status"))
-		.addFilter("userFilter", SimpleBeanPropertyFilter.serializeAllExcept("type"))
-		.addFilter("codeStubFilter", SimpleBeanPropertyFilter.serializeAllExcept("label"))
+	private val healthElementFilter = Pair("healthElementFilter", SimpleBeanPropertyFilter.serializeAllExcept("status"))
+	private val userFilter = Pair("userFilter", SimpleBeanPropertyFilter.serializeAllExcept("type"))
+	private val codeStubFilter = Pair("codeStubFilter", SimpleBeanPropertyFilter.serializeAllExcept("label"))
+	private val dataAttachmentFilterNoStoredDataSize = Pair("dataAttachmentFilter", SimpleBeanPropertyFilter.serializeAllExcept("storedDataSize"))
+	private val dataAttachmentFilterFull = Pair("dataAttachmentFilter", SimpleBeanPropertyFilter.serializeAll())
+	private val documentNoMainAttachmentSize = Pair("documentFilter", SimpleBeanPropertyFilter.serializeAllExcept("mainAttachmentRealDataSize"))
+	private val documentFull = Pair("documentFilter", SimpleBeanPropertyFilter.serializeAll())
 
-	protected val cardinalObjectMapper: ObjectMapper =
+	private fun makeCardinalObjectMapper(
+		filters: List<Pair<String, SimpleBeanPropertyFilter>>
+	): ObjectMapper =
 		ObjectMapper().registerModule(
 			KotlinModule.Builder()
 				.configure(KotlinFeature.NullIsSameAsDefault, true)
 				.build()
 		).apply {
-			setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-			setFilterProvider(cardinalJacksonFilter)
+			setDefaultPropertyInclusion(JsonInclude.Include.NON_EMPTY)
+			setFilterProvider(
+				filters.fold(SimpleFilterProvider()) { filters, (name, filter) ->
+					filters.addFilter(name, filter)
+				}
+			)
 		}
 
+	protected val cardinalMappers = object : CardinalMappers {
+		override val byMinVersion: TreeMap<SemanticVersion, ObjectMapper> = TreeMap<SemanticVersion, ObjectMapper>().apply {
+			put(
+				CardinalVersionConfig.minCardinalModelVersion,
+				makeCardinalObjectMapper(listOf(
+					healthElementFilter,
+					userFilter,
+					codeStubFilter,
+					dataAttachmentFilterNoStoredDataSize
+				))
+			)
+			put(
+				SemanticVersion("2.4.0"),
+				makeCardinalObjectMapper(listOf(
+					healthElementFilter,
+					userFilter,
+					codeStubFilter,
+					dataAttachmentFilterFull
+				))
+			)
+		}
+	}
+
 	@Bean
-	open fun cardinalObjectMapper() = cardinalObjectMapper
+	open fun cardinalObjectMapper() = cardinalMappers
 
 	abstract fun getJackson2JsonEncoder(): Encoder<Any>
 

--- a/core/src/main/kotlin/org/taktik/icure/config/SharedWebConfig.kt
+++ b/core/src/main/kotlin/org/taktik/icure/config/SharedWebConfig.kt
@@ -104,7 +104,7 @@ abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
 	private val codeStubFilter = Pair("codeStubFilter", SimpleBeanPropertyFilter.serializeAllExcept("label"))
 	private val dataAttachmentFilterNoStoredDataSize = Pair("dataAttachmentFilter", SimpleBeanPropertyFilter.serializeAllExcept("storedDataSize"))
 	private val dataAttachmentFilterFull = Pair("dataAttachmentFilter", SimpleBeanPropertyFilter.serializeAll())
-	private val documentNoMainAttachmentSize = Pair("documentFilter", SimpleBeanPropertyFilter.serializeAllExcept("mainAttachmentRealDataSize"))
+	private val documentNoMainAttachmentSize = Pair("documentFilter", SimpleBeanPropertyFilter.serializeAllExcept("mainAttachmentStoredDataSize"))
 	private val documentFull = Pair("documentFilter", SimpleBeanPropertyFilter.serializeAll())
 
 	private fun makeCardinalObjectMapper(
@@ -131,7 +131,8 @@ abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
 					healthElementFilter,
 					userFilter,
 					codeStubFilter,
-					dataAttachmentFilterNoStoredDataSize
+					dataAttachmentFilterNoStoredDataSize,
+					documentNoMainAttachmentSize
 				))
 			)
 			put(
@@ -140,7 +141,8 @@ abstract class SharedWebFluxConfiguration : WebFluxConfigurer {
 					healthElementFilter,
 					userFilter,
 					codeStubFilter,
-					dataAttachmentFilterFull
+					dataAttachmentFilterFull,
+					documentFull
 				))
 			)
 		}

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/DocumentController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/DocumentController.kt
@@ -60,6 +60,7 @@ import org.taktik.icure.services.external.rest.v1.dto.requests.document.BulkAtta
 import org.taktik.icure.services.external.rest.v1.mapper.DocumentMapper
 import org.taktik.icure.services.external.rest.v1.mapper.StubMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.DelegationMapper
+import org.taktik.icure.utils.enforceSize
 import org.taktik.icure.utils.injectReactorContext
 import org.taktik.icure.utils.toByteArray
 import reactor.core.publisher.Flux
@@ -277,24 +278,33 @@ class DocumentController(
 				"`enckeys` must contain at least a valid aes key",
 			)
 		}
+		val sizeCheckedPayload = if (size != null) payload.enforceSize(size) else payload
 		val (newPayload, newSize, encrypted) =
 			if (validEncryptionKeys?.isNotEmpty() == true) {
 				Triple(
 					// Encryption should never fail if the key is valid
 					CryptoUtils
-						.encryptFlowAES(payload, validEncryptionKeys.first())
+						.encryptFlowAES(sizeCheckedPayload, validEncryptionKeys.first())
 						.map { DefaultDataBufferFactory.sharedInstance.wrap(it) },
 					size?.let { CryptoUtils.predictAESEncryptedSize(it) },
 					true,
 				)
 			} else {
-				Triple(payload, size, false)
+				Triple(sizeCheckedPayload, size, false)
 			}
 		val document = documentService.getDocument(documentId) ?: throw NotFoundRequestException("Document not found")
 		checkRevision(rev, document)
 		val mainAttachmentChange =
 			if (newSize != null) {
-				DataAttachmentChange.CreateOrUpdate(newPayload, newSize, utis, encrypted)
+				DataAttachmentChange.CreateOrUpdate(
+					newPayload,
+					newSize,
+					utis,
+					encrypted,
+					null,
+					null,
+					null
+				)
 			} else {
 				newPayload.toByteArray(true).let { payloadBytes ->
 					DataAttachmentChange.CreateOrUpdate(
@@ -302,6 +312,9 @@ class DocumentController(
 						payloadBytes.size.toLong(),
 						utis,
 						encrypted,
+						null,
+						null,
+						null
 					)
 				}
 			}
@@ -557,6 +570,9 @@ class DocumentController(
 							attachmentSize,
 							utis,
 							false,
+							null,
+							null,
+							null
 						),
 				),
 			).let { documentMapper.map(checkNotNull(it) { "Could not update document" }) }
@@ -695,6 +711,9 @@ class DocumentController(
 		),
 		metadata?.utis,
 		false,
+		null,
+		null,
+		null,
 	)
 
 	private fun checkRevision(

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/DocumentController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/DocumentController.kt
@@ -69,6 +69,7 @@ import org.taktik.icure.services.external.rest.v2.mapper.filter.FilterV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.requests.DocumentBulkShareResultV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.requests.EntityShareOrMetadataUpdateRequestV2Mapper
 import org.taktik.icure.services.external.rest.v2.utils.addAttachmentResponseHeader
+import org.taktik.icure.utils.enforceSize
 import org.taktik.icure.utils.injectCachedReactorContext
 import org.taktik.icure.utils.injectReactorContext
 import org.taktik.icure.utils.orThrow
@@ -232,6 +233,12 @@ class DocumentController(
 		@RequestParam(required = false)
 		@Parameter(description = "Utis for the attachment")
 		utis: List<String>?,
+		@RequestParam(required = false)
+		compressionAlgorithm: String?,
+		@RequestParam(required = false)
+		triedCompressionAlgorithmsVersion: String?,
+		@RequestParam(required = false)
+		realDataSize: Long?,
 		@Schema(type = "string", format = "binary")
 		@RequestBody
 		payload: Flow<DataBuffer>,
@@ -248,7 +255,15 @@ class DocumentController(
 			.updateAttachmentsWrappingExceptions(
 				documentId,
 				rev,
-				mainAttachmentChange = DataAttachmentChange.CreateOrUpdate(payload, payloadSize, utis, encrypted ?: false),
+				mainAttachmentChange = DataAttachmentChange.CreateOrUpdate(
+					data = payload.enforceSize(payloadSize),
+					size = payloadSize,
+					utis = utis,
+					dataIsEncrypted = encrypted ?: false,
+					compressionAlgorithm = compressionAlgorithm,
+					triedCompressionAlgorithmsVersion = triedCompressionAlgorithmsVersion,
+					realDataSize = realDataSize
+				),
 			)?.let { documentV2Mapper.map(it) }
 	}
 
@@ -380,6 +395,12 @@ class DocumentController(
 		@RequestParam(required = false)
 		@Parameter(description = "Utis for the attachment")
 		utis: List<String>?,
+		@RequestParam(required = false)
+		compressionAlgorithm: String?,
+		@RequestParam(required = false)
+		triedCompressionAlgorithmsVersion: String?,
+		@RequestParam(required = false)
+		realDataSize: Long?,
 		@Schema(type = "string", format = "binary")
 		@RequestBody
 		payload: Flow<DataBuffer>,
@@ -404,10 +425,13 @@ class DocumentController(
 				mapOf(
 					key to
 						DataAttachmentChange.CreateOrUpdate(
-							payload,
-							attachmentSize,
-							utis,
-							encrypted ?: false,
+							data = payload,
+							size = attachmentSize,
+							utis = utis,
+							dataIsEncrypted = encrypted ?: false,
+							compressionAlgorithm = compressionAlgorithm,
+							triedCompressionAlgorithmsVersion = triedCompressionAlgorithmsVersion,
+							realDataSize = realDataSize
 						),
 				),
 			).let { documentV2Mapper.map(checkNotNull(it) { "Could not update document" }) }
@@ -534,15 +558,21 @@ class DocumentController(
 		name: String,
 		part: FilePart,
 		metadata: BulkAttachmentUpdateOptions.AttachmentMetadata?,
-	) = DataAttachmentChange.CreateOrUpdate(
-		part.content().asFlow(),
-		part.headers().contentLength.takeIf { it > 0 } ?: throw ResponseStatusException(
+	): DataAttachmentChange.CreateOrUpdate {
+		val size = part.headers().contentLength.takeIf { it > 0 } ?: throw ResponseStatusException(
 			HttpStatus.BAD_REQUEST,
 			"Missing size information for $name: you must provide the size of the attachment in bytes using a Content-Length part header.",
-		),
-		metadata?.utis,
-		metadata?.dataIsEncrypted ?: false,
-	)
+		)
+		return DataAttachmentChange.CreateOrUpdate(
+			data = part.content().asFlow().enforceSize(size),
+			size = size,
+			utis = metadata?.utis,
+			dataIsEncrypted = metadata?.dataIsEncrypted ?: false,
+			compressionAlgorithm = metadata?.compressionAlgorithm,
+			triedCompressionAlgorithmsVersion = metadata?.triedCompressionAlgorithmsVersion,
+			realDataSize = metadata?.realDataSize
+		)
+	}
 
 	private suspend fun DocumentService.updateAttachmentsWrappingExceptions(
 		documentId: String,

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/support/ReceiptController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/support/ReceiptController.kt
@@ -10,21 +10,26 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
+import org.springframework.core.io.buffer.DataBuffer
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -50,6 +55,8 @@ import org.taktik.icure.services.external.rest.v2.mapper.conflicts.MergeResultV2
 import org.taktik.icure.services.external.rest.v2.mapper.couchdb.DocIdentifierV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.requests.EntityShareOrMetadataUpdateRequestV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.requests.ReceiptBulkShareResultV2Mapper
+import org.taktik.icure.services.external.rest.v2.utils.addAttachmentResponseHeader
+import org.taktik.icure.utils.enforceSize
 import org.taktik.icure.utils.injectCachedReactorContext
 import org.taktik.icure.utils.injectReactorContext
 import org.taktik.icure.utils.writeTo
@@ -181,6 +188,18 @@ class ReceiptController(
 		attachment
 	}
 
+	@GetMapping("/{receiptId}/attachment/ofType/{blobType}", produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
+	fun getReceiptAttachmentByBlobType(
+		@PathVariable receiptId: String,
+		@PathVariable blobType: String,
+		response: ServerHttpResponse,
+	): Mono<Void> =response.writeWith(
+		receiptService.getDataAttachmentByBlobType(
+			receiptId,
+			ReceiptBlobType.valueOf(blobType)
+		).injectCachedReactorContext(reactorCacheInjector, 10)
+	)
+
 	@Operation(summary = "Creates a receipt's attachment")
 	@PutMapping("/{receiptId}/attachment/{blobType}", consumes = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
 	fun setReceiptAttachment(
@@ -200,6 +219,39 @@ class ReceiptController(
 		} else {
 			throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Receipt modification failed")
 		}
+	}
+
+	@Operation(summary = "Creates a receipt's attachment")
+	@PutMapping("/{receiptId}/dataattachment/{blobType}", consumes = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
+	fun setReceiptDataAttachment(
+		@PathVariable receiptId: String,
+		@PathVariable blobType: String,
+		@Parameter(
+			description = "Revision of the latest known version of the receipt. If it doesn't match the current revision the method will fail with CONFLICT.",
+		)
+		@RequestParam(required = true)
+		rev: String,
+		@RequestParam(required = false)
+		compressionAlgorithm: String?,
+		@RequestParam(required = false)
+		triedCompressionAlgorithmsVersion: String?,
+		@RequestParam(required = false)
+		realDataSize: Long?,
+		@RequestBody
+		payload: Flow<DataBuffer>,
+		@RequestHeader(name = HttpHeaders.CONTENT_LENGTH, required = false)
+		lengthHeader: Long?,
+	): Mono<ReceiptDto> = reactorCacheInjector.monoWithCachedContext(10) {
+		receiptV2Mapper.map(receiptService.putReceiptAttachmentInfo(
+			receiptId,
+			rev,
+			ReceiptBlobType.valueOf(blobType),
+			compressionAlgorithm,
+			triedCompressionAlgorithmsVersion,
+			realDataSize,
+			requireNotNull(lengthHeader) { "Must provide content length for this request" },
+			payload.enforceSize(lengthHeader)
+		))
 	}
 
 	@Operation(summary = "Get a Receipt")

--- a/domain/src/main/kotlin/org/taktik/icure/entities/Document.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/Document.kt
@@ -119,6 +119,10 @@ data class Document(
 	)
 	val otherUtis: Set<String> = emptySet(),
 
+	val mainAttachmentRealDataSize: Long? = null,
+
+	val extraMainAttachmentInfo: ExtraMainAttachmentInfo? = null,
+
 	@MergeStrategyUse(
 		canMerge = "true",
 		merge = "allDataAttachments - {{LEFT}}.mainAttachmentKey",
@@ -146,6 +150,12 @@ data class Document(
 		fun mainAttachmentKeyFromId(id: String) = id
 	}
 
+	data class ExtraMainAttachmentInfo(
+		val compressionAlgorithm: String? = null,
+		val triedCompressionAlgorithmsVersion: String? = null,
+		val storedDataSize: Long? = null,
+	)
+
 	@get:JsonIgnore
 	val mainAttachmentKey: String get() = mainAttachmentKeyFromId(id)
 
@@ -156,6 +166,10 @@ data class Document(
 				attachmentId,
 				objectStoreReference,
 				listOfNotNull(mainUti) + (mainUti?.let { otherUtis - it } ?: otherUtis),
+				extraMainAttachmentInfo?.compressionAlgorithm,
+				extraMainAttachmentInfo?.triedCompressionAlgorithmsVersion,
+				extraMainAttachmentInfo?.storedDataSize,
+				mainAttachmentRealDataSize
 			)
 		} else {
 			null
@@ -211,6 +225,20 @@ data class Document(
 		objectStoreReference = newMainAttachment?.objectStoreAttachmentId,
 		mainUti = mainUtiOf(newMainAttachment),
 		otherUtis = otherUtisOf(newMainAttachment),
+		mainAttachmentRealDataSize = newMainAttachment?.realDataSize,
+		extraMainAttachmentInfo = if (
+			newMainAttachment != null && (
+				newMainAttachment.compressionAlgorithm != null
+					|| newMainAttachment.triedCompressionAlgorithmsVersion != null
+					|| newMainAttachment.storedDataSize != null
+			)
+		) {
+			ExtraMainAttachmentInfo(
+				compressionAlgorithm = newMainAttachment.compressionAlgorithm,
+				triedCompressionAlgorithmsVersion = newMainAttachment.triedCompressionAlgorithmsVersion,
+				storedDataSize = newMainAttachment.storedDataSize,
+			)
+		} else null
 	)
 
 	private fun mainUtiOf(mainAttachment: DataAttachment?) = mainAttachment?.utis?.firstOrNull()

--- a/domain/src/main/kotlin/org/taktik/icure/entities/Document.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/Document.kt
@@ -119,7 +119,7 @@ data class Document(
 	)
 	val otherUtis: Set<String> = emptySet(),
 
-	val mainAttachmentRealDataSize: Long? = null,
+	val mainAttachmentStoredDataSize: Long? = null,
 
 	val extraMainAttachmentInfo: ExtraMainAttachmentInfo? = null,
 
@@ -142,7 +142,7 @@ data class Document(
 	@param:JsonProperty("_conflicts") override val conflicts: List<String>? = null,
 	@param:JsonProperty("rev_history") override val revHistory: Map<String, String>? = null,
 
-) : StoredICureDocument,
+	) : StoredICureDocument,
 	HasEncryptionMetadata,
 	HasDataAttachments<Document>,
 	Encryptable {
@@ -153,7 +153,7 @@ data class Document(
 	data class ExtraMainAttachmentInfo(
 		val compressionAlgorithm: String? = null,
 		val triedCompressionAlgorithmsVersion: String? = null,
-		val storedDataSize: Long? = null,
+		val realDataSize: Long? = null,
 	)
 
 	@get:JsonIgnore
@@ -163,13 +163,13 @@ data class Document(
 	val mainAttachment: DataAttachment? by lazy {
 		if (attachmentId != null || objectStoreReference != null) {
 			DataAttachment(
-				attachmentId,
-				objectStoreReference,
-				listOfNotNull(mainUti) + (mainUti?.let { otherUtis - it } ?: otherUtis),
-				extraMainAttachmentInfo?.compressionAlgorithm,
-				extraMainAttachmentInfo?.triedCompressionAlgorithmsVersion,
-				extraMainAttachmentInfo?.storedDataSize,
-				mainAttachmentRealDataSize
+				couchDbAttachmentId = attachmentId,
+				objectStoreAttachmentId = objectStoreReference,
+				utis = listOfNotNull(mainUti) + (mainUti?.let { otherUtis - it } ?: otherUtis),
+				compressionAlgorithm = extraMainAttachmentInfo?.compressionAlgorithm,
+				triedCompressionAlgorithmsVersion = extraMainAttachmentInfo?.triedCompressionAlgorithmsVersion,
+				storedDataSize = mainAttachmentStoredDataSize,
+				realDataSize = extraMainAttachmentInfo?.realDataSize,
 			)
 		} else {
 			null
@@ -225,18 +225,18 @@ data class Document(
 		objectStoreReference = newMainAttachment?.objectStoreAttachmentId,
 		mainUti = mainUtiOf(newMainAttachment),
 		otherUtis = otherUtisOf(newMainAttachment),
-		mainAttachmentRealDataSize = newMainAttachment?.realDataSize,
+		mainAttachmentStoredDataSize = newMainAttachment?.storedDataSize,
 		extraMainAttachmentInfo = if (
 			newMainAttachment != null && (
 				newMainAttachment.compressionAlgorithm != null
 					|| newMainAttachment.triedCompressionAlgorithmsVersion != null
-					|| newMainAttachment.storedDataSize != null
+					|| newMainAttachment.realDataSize != null
 			)
 		) {
 			ExtraMainAttachmentInfo(
 				compressionAlgorithm = newMainAttachment.compressionAlgorithm,
 				triedCompressionAlgorithmsVersion = newMainAttachment.triedCompressionAlgorithmsVersion,
-				storedDataSize = newMainAttachment.storedDataSize,
+				realDataSize = newMainAttachment.realDataSize,
 			)
 		} else null
 	)

--- a/domain/src/main/kotlin/org/taktik/icure/entities/Receipt.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/Receipt.kt
@@ -3,19 +3,23 @@
  */
 package org.taktik.icure.entities
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.taktik.couchdb.entity.Attachment
 import org.taktik.icure.entities.base.CodeStub
+import org.taktik.icure.entities.base.HasDataAttachments
 import org.taktik.icure.entities.base.HasEncryptionMetadata
 import org.taktik.icure.entities.base.StoredICureDocument
 import org.taktik.icure.entities.embed.Delegation
+import org.taktik.icure.entities.embed.DeletedAttachment
 import org.taktik.icure.entities.embed.Encryptable
 import org.taktik.icure.entities.embed.ReceiptBlobType
 import org.taktik.icure.entities.embed.RevisionInfo
 import org.taktik.icure.entities.embed.SecurityMetadata
+import org.taktik.icure.entities.objectstorage.DataAttachment
 import org.taktik.icure.handlers.JacksonLenientCollectionDeserializer
 import org.taktik.icure.mergers.annotations.Mergeable
 import org.taktik.icure.validation.AutoFix
@@ -39,6 +43,8 @@ data class Receipt(
 	@param:JsonProperty("deleted") override val deletionDate: Long? = null,
 
 	val attachmentIds: Map<ReceiptBlobType, String> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_EMPTY) val attachmentInfos: Map<ReceiptBlobType, DataAttachment> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_EMPTY) override val deletedAttachments: List<DeletedAttachment> = emptyList(),
 
 	@param:JsonDeserialize(using = JacksonLenientCollectionDeserializer::class)
 	val references: List<String> = emptyList(), // nipReference:027263GFF152, errorCode:186, errorPath:/request/transaction, org.taktik.icure.entities;tarification:id, org.taktik.entities.Invoice:UUID
@@ -59,9 +65,26 @@ data class Receipt(
 	@param:JsonProperty("_conflicts") override val conflicts: List<String>? = null,
 	@param:JsonProperty("rev_history") override val revHistory: Map<String, String>? = null,
 
-) : StoredICureDocument,
+	) : StoredICureDocument,
 	HasEncryptionMetadata,
+	HasDataAttachments<Receipt>,
 	Encryptable {
+		override val dataAttachments: Map<String, DataAttachment>
+			@JsonIgnore
+			get() = attachmentInfos.mapKeys { it.key.name }
+
+	override fun withUpdatedDataAttachment(
+		key: String,
+		newValue: DataAttachment?
+	) =  this.copy(
+		attachmentInfos = if (newValue != null) attachmentInfos + (ReceiptBlobType.valueOf(key) to newValue) else attachmentInfos - ReceiptBlobType.valueOf(key)
+	)
+
+	override fun withDataAttachments(newDataAttachments: Map<String, DataAttachment>) = this.copy(
+		attachmentInfos = newDataAttachments.mapKeys { ReceiptBlobType.valueOf(it.key) }
+	)
+
+	override fun withDeletedAttachments(newDeletedAttachments: List<DeletedAttachment>) = this.copy(deletedAttachments = newDeletedAttachments)
 
 	override fun withIdRev(id: String?, rev: String) = if (id != null) this.copy(id = id, rev = rev) else this.copy(rev = rev)
 	override fun withDeletionDate(deletionDate: Long?) = this.copy(deletionDate = deletionDate)

--- a/domain/src/main/kotlin/org/taktik/icure/entities/Receipt.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/Receipt.kt
@@ -69,9 +69,8 @@ data class Receipt(
 	HasEncryptionMetadata,
 	HasDataAttachments<Receipt>,
 	Encryptable {
-		override val dataAttachments: Map<String, DataAttachment>
-			@JsonIgnore
-			get() = attachmentInfos.mapKeys { it.key.name }
+		@get:JsonIgnore
+		override val dataAttachments: Map<String, DataAttachment> by lazy { attachmentInfos.mapKeys { it.key.name } }
 
 	override fun withUpdatedDataAttachment(
 		key: String,

--- a/domain/src/main/kotlin/org/taktik/icure/entities/objectstorage/DataAttachment.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/objectstorage/DataAttachment.kt
@@ -21,8 +21,28 @@ data class DataAttachment(
 	val couchDbAttachmentId: String? = null,
 	val objectStoreAttachmentId: String? = null,
 	val utis: List<String> = emptyList(),
-	val compressionAlgorithm: String? = null, //lzma,gz... null means not compressed
-	val triedCompressionAlgorithmsVersion: String? = null, //null means never tried to compress
+	/**
+	 * Algorithm used on the CLIENT SIDE to compress the data attachment.
+	 * Null means that the document was not compressed because the tried algorithms could not actually compress the data
+	 * (because for example it was an already compressed format) or no algorithms were tried.
+	 */
+	val compressionAlgorithm: String? = null,
+	/**
+	 * A string used by the SDK to mark which compression algorithms were tried.
+	 * Null means that no compression algorithms were tried.
+	 * If an SDK reads some data that is not compressed, if this value indicates that the data was created with an older
+	 * version of the SDK then the SDK may try to use any newly available algorithms to compress the data.
+	 */
+	val triedCompressionAlgorithmsVersion: String? = null,
+	/**
+	 * Value computed by the backend, the actual size of the data stored for the attachment, in bytes.
+	 */
+	val storedDataSize: Long? = null,
+	/**
+	 * Value provided by the client, the real size of the data after it has been decrypted and decompressed, in bytes.
+	 * This value is not used or verified by the backend.
+	 */
+	val realDataSize: Long? = null,
 ) {
 	init {
 		require(couchDbAttachmentId != null || objectStoreAttachmentId != null) {
@@ -44,9 +64,6 @@ data class DataAttachment(
 	@JsonIgnore
 	private var cachedBytes: ByteArray? = null
 
-	@get:JsonIgnore
-	val ids: Pair<String?, String?> get() = couchDbAttachmentId to objectStoreAttachmentId
-
 	/**
 	 * Get the mime type string for this attachment. If the attachment does not specify a UTI with a valid mime type returns null.
 	 */
@@ -60,19 +77,6 @@ data class DataAttachment(
 	@get:JsonIgnore
 	val mimeTypeOrDefault: String get() =
 		mimeType ?: DEFAULT_MIME_TYPE
-
-	/**
-	 * @return if this and other attachment have the same ids (the attachment is the same and is stored in the same place)
-	 */
-	infix fun hasSameIdsAs(other: DataAttachment) = this.ids == other.ids
-
-	/**
-	 * @return a copy of this data attachment where the ids are replaced with those of another data attachment
-	 */
-	fun withIdsOf(other: DataAttachment) = copy(
-		couchDbAttachmentId = other.couchDbAttachmentId,
-		objectStoreAttachmentId = other.objectStoreAttachmentId,
-	)
 
 	/**
 	 * Get the attachment content as bytes. If the content has been cached immediately returns it, otherwise loads the content from

--- a/domain/src/main/kotlin/org/taktik/icure/entities/objectstorage/DataAttachment.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/objectstorage/DataAttachment.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import kotlinx.coroutines.flow.Flow
 import org.taktik.commons.uti.UTI
+import org.taktik.icure.entities.objectstorage.DataAttachment.Companion.DEFAULT_MIME_TYPE
 
 /**
  * Represent an attachment holding some additional data for an entity.
@@ -19,7 +20,9 @@ import org.taktik.commons.uti.UTI
 data class DataAttachment(
 	val couchDbAttachmentId: String? = null,
 	val objectStoreAttachmentId: String? = null,
-	val utis: List<String> = emptyList()
+	val utis: List<String> = emptyList(),
+	val compressionAlgorithm: String? = null, //lzma,gz... null means not compressed
+	val triedCompressionAlgorithmsVersion: String? = null, //null means never tried to compress
 ) {
 	init {
 		require(couchDbAttachmentId != null || objectStoreAttachmentId != null) {

--- a/domain/src/main/kotlin/org/taktik/icure/entities/utils/SemanticVersion.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/utils/SemanticVersion.kt
@@ -1,27 +1,36 @@
 package org.taktik.icure.entities.utils
 
-private val semVerRegex = Regex("^([0-9]+)\\.([0-9]+)\\.([0-9]+)([\\-A-Za-z0-9.]*)\$")
-
 @JvmInline
 value class SemanticVersion(val version: String) : Comparable<SemanticVersion> {
 
-	init {
-		require(version.matches(semVerRegex)) {
-			"Invalid semantic version syntax"
-		}
+	private fun asIntComponentNoSuffix(component: String): Int = buildString {
+		component
+			.takeWhile { it in '0'..'9' }
+			.forEach { append(it) }
+	}.toInt()
+
+	private fun getComponentSuffix(component: String): String = component.dropWhile {
+		it in '0'..'9'
 	}
 
 	override fun compareTo(other: SemanticVersion): Int {
-		val thisMatch = checkNotNull(semVerRegex.find(version)) {
-			"Cannot match version: $version"
+		val thisSplit = version.split('.').also {
+			require(it.size == 3) { "Invalid version format: $version" }
 		}
-		val otherMatch = checkNotNull(semVerRegex.find(other.version)) {
-			"Cannot match version: $version"
+		val otherSplit = other.version.split('.').also {
+			require(it.size == 3) { "Invalid version format: ${other.version}" }
 		}
-		return thisMatch.groupValues[1].toInt().compareTo(otherMatch.groupValues[1].toInt()).takeIf { it != 0 }
-			?: thisMatch.groupValues[2].toInt().compareTo(otherMatch.groupValues[2].toInt()).takeIf { it != 0 }
-			?: thisMatch.groupValues[3].toInt().compareTo(otherMatch.groupValues[3].toInt()).takeIf {
-				it != 0 || (thisMatch.groupValues.size == 3 && otherMatch.groupValues.size == 4)
-			} ?: thisMatch.groupValues.getOrElse(4) { "" }.compareTo(otherMatch.groupValues.getOrElse(4) { "" })
+		return thisSplit[0].toInt().compareTo(otherSplit[0].toInt()).takeIf { it != 0 }
+			?: thisSplit[1].toInt().compareTo(otherSplit[1].toInt()).takeIf { it != 0 }
+			?: asIntComponentNoSuffix(thisSplit[2]).compareTo(asIntComponentNoSuffix(otherSplit[2])).takeIf { it != 0 }
+			?: getComponentSuffix(thisSplit[2]).let { thisSuffix ->
+				val otherSuffix = getComponentSuffix(otherSplit[2])
+				when {
+					thisSuffix.isEmpty() && otherSuffix.isEmpty() -> 0
+					thisSuffix.isEmpty() -> 1
+					otherSuffix.isEmpty() -> -1
+					else -> thisSuffix.compareTo(otherSuffix)
+				}
+			}
 	}
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/ReceiptDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/ReceiptDto.kt
@@ -9,7 +9,9 @@ import org.taktik.icure.services.external.rest.v1.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v1.dto.base.HasEncryptionMetadataDto
 import org.taktik.icure.services.external.rest.v1.dto.base.ICureDocumentDto
 import org.taktik.icure.services.external.rest.v1.dto.base.StoredDocumentDto
+import org.taktik.icure.services.external.rest.v1.dto.embed.DataAttachmentDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.DelegationDto
+import org.taktik.icure.services.external.rest.v1.dto.embed.DeletedAttachmentDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.ReceiptBlobTypeDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.SecurityMetadataDto
@@ -29,6 +31,8 @@ data class ReceiptDto(
 	override val endOfLife: Long? = null,
 	override val deletionDate: Long? = null,
 	val attachmentIds: Map<ReceiptBlobTypeDto, String> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_EMPTY) val attachmentInfos: Map<ReceiptBlobTypeDto, DataAttachmentDto> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_EMPTY) val deletedAttachments: List<DeletedAttachmentDto> = emptyList(),
 	val references: List<String> = emptyList(), // nipReference:027263GFF152, errorCode:186, errorPath:/request/transaction, org.taktik.icure.services.external.rest.v1.dto;tarification:id, org.taktik.entities.InvoiceDto:UUID
 	// The ICureDocumentDto (InvoiceDto, ContactDto, ...) this document is linked to
 	val documentId: String? = null,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/DataAttachmentDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/embed/DataAttachmentDto.kt
@@ -13,4 +13,26 @@ data class DataAttachmentDto(
 	@param:Schema(
 		description = "The Uniform Type Identifiers (https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-CHDHIJDE) of the attachment. This is a list to allow representing a priority, but each UTI must be unique.",
 	) val utis: List<String> = emptyList(),
+	/**
+	 * Algorithm used on the CLIENT SIDE to compress the data attachment.
+	 * Null means that the document was not compressed because the tried algorithms could not actually compress the data
+	 * (because for example it was an already compressed format) or no algorithms were tried.
+	 */
+	val compressionAlgorithm: String? = null,
+	/**
+	 * A string used by the SDK to mark which compression algorithms were tried.
+	 * Null means that no compression algorithms were tried.
+	 * If an SDK reads some data that is not compressed, if this value indicates that the data was created with an older
+	 * version of the SDK then the SDK may try to use any newly available algorithms to compress the data.
+	 */
+	val triedCompressionAlgorithmsVersion: String? = null,
+	/**
+	 * Value computed by the backend, the actual size of the data stored for the attachment, in bytes.
+	 */
+	val storedDataSize: Long? = null,
+	/**
+	 * Value provided by the client, the real size of the data after it has been decrypted and decompressed, in bytes.
+	 * This value is not used or verified by the backend.
+	 */
+	val realDataSize: Long? = null,
 ) : Serializable

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/notification/SubscriptionDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/notification/SubscriptionDto.kt
@@ -14,6 +14,7 @@ data class SubscriptionDto<O : IdentifiableDto<String>>(
 	val filter: FilterChain<O>?,
 	val accessControlKeys: List<HexString>? = null,
 	val useCardinalModelSerialization: Boolean? = null,
+	val cardinalSdkVersion: String? = null,
 ) : java.io.Serializable {
 	enum class EventType {
 		CREATE,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/requests/document/BulkAttachmentUpdateOptions.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/requests/document/BulkAttachmentUpdateOptions.kt
@@ -16,5 +16,6 @@ data class BulkAttachmentUpdateOptions(
 			description = "The Uniform Type Identifiers (https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-CHDHIJDE) of the attachment. This is a list to allow representing a priority, but each UTI must be unique.",
 		)
 		val utis: List<String> = emptyList(),
+
 	) : Serializable
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DocumentDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DocumentDto.kt
@@ -19,7 +19,6 @@ package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonFilter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
@@ -109,7 +108,7 @@ data class DocumentDto(
 	) val mainUti: String? = null,
 	/** Extra Uniform Type Identifiers for the main attachment. */
 	@param:Schema(description = "Extra Uniform Type Identifiers for the main attachment") val otherUtis: Set<String> = emptySet(),
-	val mainAttachmentRealDataSize: Long? = null,
+	val mainAttachmentStoredDataSize: Long? = null,
 	val extraMainAttachmentInfo: ExtraMainAttachmentInfo? = null,
 	/** Secondary attachments for this document. */
 	@param:Schema(description = "Secondary attachments for this document") val secondaryAttachments: Map<String, DataAttachmentDto> = emptyMap(),
@@ -149,6 +148,6 @@ data class DocumentDto(
 	data class ExtraMainAttachmentInfo(
 		val compressionAlgorithm: String? = null,
 		val triedCompressionAlgorithmsVersion: String? = null,
-		val storedDataSize: Long? = null,
+		val realDataSize: Long? = null,
 	)
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DocumentDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/DocumentDto.kt
@@ -17,6 +17,7 @@
  */
 package org.taktik.icure.services.external.rest.v2.dto
 
+import com.fasterxml.jackson.annotation.JsonFilter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
@@ -38,6 +39,7 @@ import org.taktik.icure.services.external.rest.v2.dto.specializations.Base64Stri
 @Schema(
 	description = """This entity is a root level object. It represents a Document. It is serialized in JSON and saved in the underlying CouchDB database.""",
 )
+@JsonFilter("documentFilter")
 /**
  * Represents a document entity stored in CouchDB. Documents can have main and secondary data attachments,
  * and support various storage backends (CouchDB attachments, object storage).
@@ -107,6 +109,8 @@ data class DocumentDto(
 	) val mainUti: String? = null,
 	/** Extra Uniform Type Identifiers for the main attachment. */
 	@param:Schema(description = "Extra Uniform Type Identifiers for the main attachment") val otherUtis: Set<String> = emptySet(),
+	val mainAttachmentRealDataSize: Long? = null,
+	val extraMainAttachmentInfo: ExtraMainAttachmentInfo? = null,
 	/** Secondary attachments for this document. */
 	@param:Schema(description = "Secondary attachments for this document") val secondaryAttachments: Map<String, DataAttachmentDto> = emptyMap(),
 	/** Information on past attachments for this document. */
@@ -141,4 +145,10 @@ data class DocumentDto(
 	) = if (id != null) this.copy(id = id, rev = rev) else this.copy(rev = rev)
 
 	override fun withDeletionDate(deletionDate: Long?) = this.copy(deletionDate = deletionDate)
+
+	data class ExtraMainAttachmentInfo(
+		val compressionAlgorithm: String? = null,
+		val triedCompressionAlgorithmsVersion: String? = null,
+		val storedDataSize: Long? = null,
+	)
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ReceiptDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/ReceiptDto.kt
@@ -18,11 +18,14 @@
 package org.taktik.icure.services.external.rest.v2.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeStubDto
 import org.taktik.icure.services.external.rest.v2.dto.base.HasEncryptionMetadataDto
 import org.taktik.icure.services.external.rest.v2.dto.base.ICureDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
+import org.taktik.icure.services.external.rest.v2.dto.embed.DataAttachmentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.DelegationDto
+import org.taktik.icure.services.external.rest.v2.dto.embed.DeletedAttachmentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.EncryptableDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.ReceiptBlobTypeDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.SecurityMetadataDto
@@ -60,8 +63,9 @@ data class ReceiptDto(
 	/** Hard delete (unix epoch in ms) timestamp of the object. */
 	override val deletionDate: Long? = null,
 	/** Map of blob type to attachment id for the receipt. */
-	@Deprecated("This field is deprecated for the use with Cardinal SDK")
 	val attachmentIds: Map<ReceiptBlobTypeDto, String> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_EMPTY) val attachmentInfos: Map<ReceiptBlobTypeDto, DataAttachmentDto> = emptyMap(),
+	@param:JsonInclude(JsonInclude.Include.NON_EMPTY) val deletedAttachments: List<DeletedAttachmentDto> = emptyList(),
 	/** List of references (e.g., nipReference, errorCode, errorPath, tarification, invoice UUID). */
 	val references: List<String> = emptyList(), // nipReference:027263GFF152, errorCode:186, errorPath:/request/transaction, org.taktik.icure.services.external.rest.v2.dto;tarification:id, org.taktik.entities.InvoiceDto:UUID
 	// The ICureDocumentDto (InvoiceDto, ContactDto, ...) this document is linked to

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/DataAttachmentDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/DataAttachmentDto.kt
@@ -1,5 +1,6 @@
 package org.taktik.icure.services.external.rest.v2.dto.embed
 
+import com.fasterxml.jackson.annotation.JsonFilter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
@@ -7,6 +8,7 @@ import java.io.Serializable
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonFilter("dataAttachmentFilter")
 /**
  * Represents a data attachment that can be stored either as a CouchDB attachment or via object storage.
  */
@@ -19,4 +21,26 @@ data class DataAttachmentDto(
 		description = "The Uniform Type Identifiers (https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-CHDHIJDE) of the attachment. This is a list to allow representing a priority, but each UTI must be unique.",
 	/** The Uniform Type Identifiers of the attachment, ordered by priority. */
 	) val utis: List<String> = emptyList(),
+	/**
+	 * Algorithm used on the CLIENT SIDE to compress the data attachment.
+	 * Null means that the document was not compressed because the tried algorithms could not actually compress the data
+	 * (because for example it was an already compressed format) or no algorithms were tried.
+	 */
+	val compressionAlgorithm: String? = null,
+	/**
+	 * A string used by the SDK to mark which compression algorithms were tried.
+	 * Null means that no compression algorithms were tried.
+	 * If an SDK reads some data that is not compressed, if this value indicates that the data was created with an older
+	 * version of the SDK then the SDK may try to use any newly available algorithms to compress the data.
+	 */
+	val triedCompressionAlgorithmsVersion: String? = null,
+	/**
+	 * Value computed by the backend, the actual size of the data stored for the attachment, in bytes.
+	 */
+	val storedDataSize: Long? = null,
+	/**
+	 * Value provided by the client, the real size of the data after it has been decrypted and decompressed, in bytes.
+	 * This value is not used or verified by the backend.
+	 */
+	val realDataSize: Long? = null,
 ) : Serializable

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/notification/SubscriptionDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/notification/SubscriptionDto.kt
@@ -26,6 +26,7 @@ data class SubscriptionDto<O : IdentifiableDto<String>>(
 	val accessControlKeys: List<AccessControlKeyHexStringDto>?,
 	/** When true, uses Cardinal model serialization for the entity payloads. */
 	val useCardinalModelSerialization: Boolean? = null,
+	val cardinalSdkVersion: String? = null,
 ) : java.io.Serializable
 
 /**

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/requests/document/BulkAttachmentUpdateOptions.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/requests/document/BulkAttachmentUpdateOptions.kt
@@ -28,5 +28,8 @@ data class BulkAttachmentUpdateOptions(
 		val utis: List<String> = emptyList(),
 		/** Whether the attachment data is encrypted. */
 		val dataIsEncrypted: Boolean? = null,
+		val compressionAlgorithm: String? = null,
+		val triedCompressionAlgorithmsVersion: String? = null,
+		val realDataSize: Long? = null,
 	) : Serializable
 }

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/ReceiptLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/ReceiptLogic.kt
@@ -41,5 +41,4 @@ interface ReceiptLogic :
 	): Receipt
 
 	fun getDataAttachmentByBlobType(receiptId: String, blobType: ReceiptBlobType): Flow<DataBuffer>
-	// TODO migrate attachment method on cloud logic?
 }

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/ReceiptLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/ReceiptLogic.kt
@@ -5,6 +5,7 @@
 package org.taktik.icure.asynclogic
 
 import kotlinx.coroutines.flow.Flow
+import org.springframework.core.io.buffer.DataBuffer
 import org.taktik.icure.asynclogic.base.EntityWithSecureDelegationsLogic
 import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.embed.ReceiptBlobType
@@ -18,5 +19,27 @@ interface ReceiptLogic :
 	suspend fun createReceipt(receipt: Receipt): Receipt
 	fun listReceiptsByReference(ref: String): Flow<Receipt>
 	fun getAttachment(receiptId: String, attachmentId: String): Flow<ByteBuffer>
+
+	/**
+	 * Add receipt attachment in the old format, with only couchdb attachments supported
+	 */
 	suspend fun addReceiptAttachment(receipt: Receipt, blobType: ReceiptBlobType, payload: ByteArray): Receipt
+
+	/**
+	 * Add or replace receipt attachment in the new format. Attachment will be stored in couchdb, but may be moved
+	 * later by an external process.
+	 */
+	suspend fun putReceiptAttachmentInfo(
+		receiptId: String,
+		receiptRev: String,
+		blobType: ReceiptBlobType,
+		compressionAlgorithm: String?,
+		triedCompressionAlgorithmsVersion: String?,
+		realDataSize: Long?,
+		storedDataSize: Long,
+		data: Flow<DataBuffer>,
+	): Receipt
+
+	fun getDataAttachmentByBlobType(receiptId: String, blobType: ReceiptBlobType): Flow<DataBuffer>
+	// TODO migrate attachment method on cloud logic?
 }

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/DataAttachmentChange.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/DataAttachmentChange.kt
@@ -2,6 +2,7 @@ package org.taktik.icure.asynclogic.objectstorage
 
 import kotlinx.coroutines.flow.Flow
 import org.springframework.core.io.buffer.DataBuffer
+import org.taktik.icure.entities.objectstorage.DataAttachment
 
 /**
  * Represents a request to change [DataAttachment]s.
@@ -17,17 +18,26 @@ sealed interface DataAttachmentChange {
 	/**
 	 * Represents a request to create or update an attachment.
 	 * @param data the content of the attachment.
-	 * @param size the size of the attachment content. This value can help to decide the most appropriate storage location for the attachment.
+	 * @param size the real size of [data] in bytes, after compression and encryption on the client side, if not
+	 * matching the update will fail. Will be saved on [DataAttachment.realDataSize]
 	 * @param utis used differently depending on whether this [DataAttachmentChange] triggers
 	 * the creation of a new [DataAttachment] or updates an existing one:
 	 * - `Update`: if not null specifies a new value for [DataAttachment.utis].
 	 * - `Create`: specifies the initial value for [DataAttachment.utis], in this case `null`
 	 *    will be converted to an empty list.
+	 * @param dataIsEncrypted if true the mime-type of the attachment in the final storage layer will be
+	 * application/octet-stream else the mime-type is taken from [utis]
+	 * @param compressionAlgorithm value to set on [DataAttachment.compressionAlgorithm]
+	 * @param triedCompressionAlgorithmsVersion value to set on [DataAttachment.triedCompressionAlgorithmsVersion]
+	 * @param realDataSize value to set on [DataAttachment.realDataSize]
 	 */
 	data class CreateOrUpdate(
 		val data: Flow<DataBuffer>,
 		val size: Long,
 		val utis: List<String>?,
 		val dataIsEncrypted: Boolean,
+		val compressionAlgorithm: String?,
+		val triedCompressionAlgorithmsVersion: String?,
+		val realDataSize: Long?,
 	) : DataAttachmentChange
 }

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/DataAttachmentLoader.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/DataAttachmentLoader.kt
@@ -3,6 +3,7 @@ package org.taktik.icure.asynclogic.objectstorage
 import kotlinx.coroutines.flow.Flow
 import org.springframework.core.io.buffer.DataBuffer
 import org.taktik.icure.entities.Document
+import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.base.HasDataAttachments
 import org.taktik.icure.entities.objectstorage.DataAttachment
 
@@ -74,3 +75,5 @@ interface DocumentDataAttachmentLoader : DataAttachmentLoader<Document> {
 		enckeys: List<String>,
 	): ByteArray? = decryptAttachment(document, enckeys, Document::mainAttachment)
 }
+
+interface ReceiptDataAttachmentLoader : DataAttachmentLoader<Receipt>

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IDataAttachmentModificationLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IDataAttachmentModificationLogic.kt
@@ -2,6 +2,7 @@ package org.taktik.icure.asynclogic.objectstorage
 
 import org.taktik.icure.entities.Document
 import org.taktik.icure.entities.base.HasDataAttachments
+import org.taktik.icure.entities.objectstorage.DataAttachment
 
 /**
  * Shared logic for the modification of entities which have [DataAttachment]s.
@@ -15,14 +16,17 @@ interface DataAttachmentModificationLogic<T : HasDataAttachments<T>> {
 	 * The following changes are considered invalid:
 	 * 1. The new version of an entity specifies some attachments which do not exist in the
 	 * current version.
-	 * 2. The new version changes the value of a [IDataAttachment.couchDbAttachmentId] or
-	 * [DataAttachment.objectStoreAttachmentId].
+	 * 2. The new version changes the value of a [DataAttachment.couchDbAttachmentId],
+	 * [DataAttachment.objectStoreAttachmentId], [DataAttachment.compressionAlgorithm], [DataAttachment.storedDataSize],
+	 * or [DataAttachment.realDataSize]
 	 * 3. Any change in the [HasDataAttachments.deletedAttachments]
 	 *
 	 * In most cases if there is an invalid change this method will throw an [IllegalArgumentException],
-	 * however it is possible to specify to have a lenient behaviour for some attachments, in order to
-	 * preserve retro-compatibility. All invalid changes to attachment data that is mapped to a key
-	 * in [lenientKeys] will be simply ignored, without triggering an [IllegalArgumentException].
+	 * however for some values there is a lenient behaviour, in order to preserve retro-compatibility.
+	 * - All invalid changes to attachment data that is mapped to a key in [lenientKeys] will be simply ignored, without
+	 * triggering an [IllegalArgumentException].
+	 * - Passing a null [DataAttachment.storedDataSize] will be allowed regardless of the current corresponding value,
+	 *   in that case the value is overridden with what was already stored
 	 *
 	 * @param currEntity the current value of the entity being updated
 	 * @param newEntity the new desired value for the entity

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorage.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorage.kt
@@ -3,6 +3,7 @@ package org.taktik.icure.asynclogic.objectstorage
 import kotlinx.coroutines.flow.Flow
 import org.springframework.core.io.buffer.DataBuffer
 import org.taktik.icure.entities.Document
+import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.base.HasDataAttachments
 import java.io.IOException
 
@@ -81,3 +82,4 @@ interface IcureObjectStorage<T : HasDataAttachments<T>> {
 }
 
 interface DocumentObjectStorage : IcureObjectStorage<Document>
+interface ReceiptObjectStorage : IcureObjectStorage<Receipt>

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigration.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigration.kt
@@ -1,5 +1,7 @@
 package org.taktik.icure.asynclogic.objectstorage
 
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
 import org.taktik.icure.entities.Document
 import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.base.HasDataAttachments
@@ -35,5 +37,22 @@ interface IcureObjectStorageMigration<T : HasDataAttachments<T>> {
 	suspend fun rescheduleStoredMigrationTasks()
 }
 
+private class NoObjectStorageMigration<T : HasDataAttachments<T>> : IcureObjectStorageMigration<T> {
+	override fun isMigrating(entity: T, attachmentId: String): Boolean = false
+
+	override suspend fun scheduleMigrateAttachment(entity: T, attachmentId: String) {
+		throw IllegalStateException("Should not schedule migration for entity of type ${entity::class.simpleName}")
+	}
+
+	override suspend fun rescheduleStoredMigrationTasks() {
+		// Do nothing
+	}
+}
+
 interface DocumentObjectStorageMigration : IcureObjectStorageMigration<Document>
 interface ReceiptObjectStorageMigration : IcureObjectStorageMigration<Receipt>
+@Service
+@Profile("app")
+class ReceiptObjectStorageMigrationImpl :
+	ReceiptObjectStorageMigration,
+	IcureObjectStorageMigration<Receipt> by NoObjectStorageMigration()

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigration.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/objectstorage/IcureObjectStorageMigration.kt
@@ -1,6 +1,7 @@
 package org.taktik.icure.asynclogic.objectstorage
 
 import org.taktik.icure.entities.Document
+import org.taktik.icure.entities.Receipt
 import org.taktik.icure.entities.base.HasDataAttachments
 
 /**
@@ -35,3 +36,4 @@ interface IcureObjectStorageMigration<T : HasDataAttachments<T>> {
 }
 
 interface DocumentObjectStorageMigration : IcureObjectStorageMigration<Document>
+interface ReceiptObjectStorageMigration : IcureObjectStorageMigration<Receipt>

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/DocumentMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/DocumentMapper.kt
@@ -33,6 +33,8 @@ interface DocumentMapper {
 		Mapping(target = "revHistory", ignore = true),
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
+		Mapping(target = "extraMainAttachmentInfo", ignore = true),
+		Mapping(target = "mainAttachmentRealDataSize", ignore = true),
 	)
 	fun map(documentDto: DocumentDto): Document
 

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/DocumentMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/DocumentMapper.kt
@@ -34,7 +34,7 @@ interface DocumentMapper {
 		Mapping(target = "conflicts", ignore = true),
 		Mapping(target = "revisionsInfo", ignore = true),
 		Mapping(target = "extraMainAttachmentInfo", ignore = true),
-		Mapping(target = "mainAttachmentRealDataSize", ignore = true),
+		Mapping(target = "mainAttachmentStoredDataSize", ignore = true),
 	)
 	fun map(documentDto: DocumentDto): Document
 

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ReceiptMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v1/mapper/ReceiptMapper.kt
@@ -11,10 +11,22 @@ import org.mapstruct.Mappings
 import org.taktik.icure.entities.Receipt
 import org.taktik.icure.services.external.rest.v1.dto.ReceiptDto
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeStubMapper
+import org.taktik.icure.services.external.rest.v1.mapper.embed.DataAttachmentMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.DelegationMapper
+import org.taktik.icure.services.external.rest.v1.mapper.embed.DeletedAttachmentMapper
 import org.taktik.icure.services.external.rest.v1.mapper.embed.SecurityMetadataMapper
 
-@Mapper(componentModel = "spring", uses = [CodeStubMapper::class, DelegationMapper::class, SecurityMetadataMapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper(
+	componentModel = "spring",
+	uses = [
+		CodeStubMapper::class,
+		DelegationMapper::class,
+		SecurityMetadataMapper::class,
+		DataAttachmentMapper::class,
+		DeletedAttachmentMapper::class,
+	],
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
 interface ReceiptMapper {
 	@Mappings(
 		Mapping(target = "attachments", ignore = true),

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/DocumentMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/DocumentMapper.kt
@@ -55,4 +55,7 @@ interface DocumentV2Mapper {
 		Mapping(target = "decryptedAttachment", ignore = true),
 	)
 	fun map(document: Document): DocumentDto
+
+	fun map(extraMainAttachmentInfoDto: DocumentDto.ExtraMainAttachmentInfo): Document.ExtraMainAttachmentInfo
+	fun map(extraMainAttachmentInfo: Document.ExtraMainAttachmentInfo): DocumentDto.ExtraMainAttachmentInfo
 }

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ReceiptMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/ReceiptMapper.kt
@@ -25,10 +25,22 @@ import org.mapstruct.Mappings
 import org.taktik.icure.entities.Receipt
 import org.taktik.icure.services.external.rest.v2.dto.ReceiptDto
 import org.taktik.icure.services.external.rest.v2.mapper.base.CodeStubV2Mapper
+import org.taktik.icure.services.external.rest.v2.mapper.embed.DataAttachmentV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.DelegationV2Mapper
+import org.taktik.icure.services.external.rest.v2.mapper.embed.DeletedAttachmentV2Mapper
 import org.taktik.icure.services.external.rest.v2.mapper.embed.SecurityMetadataV2Mapper
 
-@Mapper(componentModel = "spring", uses = [CodeStubV2Mapper::class, DelegationV2Mapper::class, SecurityMetadataV2Mapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper(
+	componentModel = "spring",
+	uses = [
+		CodeStubV2Mapper::class,
+		DelegationV2Mapper::class,
+		SecurityMetadataV2Mapper::class,
+		DataAttachmentV2Mapper::class,
+		DeletedAttachmentV2Mapper::class,
+	],
+	injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
 interface ReceiptV2Mapper {
 	@Mappings(
 		Mapping(target = "attachments", ignore = true),

--- a/service/src/main/kotlin/org/taktik/icure/asyncservice/ReceiptService.kt
+++ b/service/src/main/kotlin/org/taktik/icure/asyncservice/ReceiptService.kt
@@ -5,6 +5,7 @@
 package org.taktik.icure.asyncservice
 
 import kotlinx.coroutines.flow.Flow
+import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.security.access.AccessDeniedException
 import org.taktik.couchdb.DocIdentifier
 import org.taktik.couchdb.entity.IdAndRev
@@ -98,4 +99,20 @@ interface ReceiptService :
 	 */
 	suspend fun getReceipt(id: String): Receipt?
 	fun getReceipts(receiptIds: List<String>): Flow<Receipt>
+
+	/**
+	 * Add or replace receipt attachment in the new format. Attachment will be stored in couchdb, but may be moved
+	 * later by an external process.
+	 */
+	suspend fun putReceiptAttachmentInfo(
+		receiptId: String,
+		receiptRev: String,
+		blobType: ReceiptBlobType,
+		compressionAlgorithm: String?,
+		triedCompressionAlgorithmsVersion: String?,
+		realDataSize: Long?,
+		storedDataSize: Long,
+		data: Flow<DataBuffer>,
+	): Receipt
+	fun getDataAttachmentByBlobType(receiptId: String, blobType: ReceiptBlobType): Flow<DataBuffer>
 }

--- a/utils/src/main/kotlin/org/taktik/icure/utils/FlowUtils.kt
+++ b/utils/src/main/kotlin/org/taktik/icure/utils/FlowUtils.kt
@@ -162,6 +162,23 @@ fun InputStream.toFlow() = flow {
  */
 fun Flow<DataBuffer>.dropBytes(n: Long): Flow<DataBuffer> = if (n > 0) DataBufferUtils.skipUntilByteCount(asPublisher(), n).asFlow() else this
 
+/**
+ * Wraps this flow so that:
+ * - it throws [IllegalArgumentException] the moment the cumulative number of readable bytes exceeds [maxBytes];
+ * - once the flow is fully consumed, it throws [IllegalArgumentException] if the total is less than [maxBytes].
+ *
+ * If the flow is not fully consumed (e.g. downstream cancels early) the under-read check may not be performed.
+ */
+fun Flow<DataBuffer>.enforceSize(maxBytes: Long): Flow<DataBuffer> = flow {
+	var bytesRead = 0L
+	collect { buffer ->
+		bytesRead += buffer.readableByteCount()
+		if (bytesRead > maxBytes) throw IllegalArgumentException("Payload exceeds declared Content-Length of $maxBytes bytes")
+		emit(buffer)
+	}
+	if (bytesRead < maxBytes) throw IllegalArgumentException("Payload is smaller than declared Content-Length of $maxBytes bytes (got $bytesRead)")
+}
+
 /* TODO check if other implementation is more efficient and is also correct (does never leave trailing zeroes)
 DataBufferUtils.join(asPublisher()).awaitFirst().asByteBuffer().array()
  */


### PR DESCRIPTION
Jira: [ICBE-487](https://icure.atlassian.net/browse/ICBE-487)

- Fix DAOs not evicting cache entries when changing couchdb attachments
- Support DataAttachment on Receipt:
  - Old methods for creating and getting attachment still only use attachmentIds
  - Provide new method to set attachment in the new format. This method still stores attachment in couchdb
  - (CLOUD ONLY) Provide method to migrate new format receipt attachments to object storage
  - Provide new method to get attachments from couchdb or from 
- New fields of DataAttachment
  - Info on if the data was compressed (client-side only compression)
  - User-provided real-data size
  - Kraken-enforced stored data size
- Update Document logic to support new data attachment style
- Type-safe names for entities supporting data attachments
  

[ICBE-487]: https://icure.atlassian.net/browse/ICBE-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ