### PR TITLE
Removed Group.created from DTO

### DIFF
--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/GroupDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/GroupDto.kt
@@ -21,7 +21,6 @@ data class GroupDto(
 	@param:Schema(description = "The id of the group. We encourage using either a v4 UUID or a HL7 Id.") override val id: String,
 	@param:Schema(description = "The revision of the group in the database, used for conflict management / optimistic locking.") override val rev: String? = null,
 	override val deletionDate: Long? = null,
-	val created: Long? = null,
 	override val tags: Set<CodeStubDto> = emptySet(),
 	val publicTags: Set<CodeStubDto> = emptySet(),
 	@param:Schema(description = "Username for the group") val name: String? = null,

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/GroupDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/GroupDto.kt
@@ -44,8 +44,6 @@ data class GroupDto(
 	@param:Schema(description = "The revision of the group in the database, used for conflict management / optimistic locking.") override val rev: String? = null,
 	/** Soft delete (unix epoch in ms) timestamp of the object. */
 	override val deletionDate: Long? = null,
-	/** Creation timestamp of the group. It may be null for older groups **/
-	val created: Long? = null,
 	/** Tags that qualify the group as being member of a certain class. */
 	override val tags: Set<CodeStubDto> = emptySet(),
 	/** Tags that are publicly visible for the group. */


### PR DESCRIPTION
Jira: [ICBE-449](https://icure.atlassian.net/browse/ICBE-449)

Since this value is autofilled, there may be problems for users that create new groups on the cockpit and then try to retrieve them with an older version of the SDK.
Since the only immediate use for this is internal, it was decided to remove it from the DTO instead of adding another filter

[ICBE-449]: https://icure.atlassian.net/browse/ICBE-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ