### PR TITLE
feat(security): IcureLogContext + Reactor-Context-based suspend logger

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/security/IcureLogContext.kt
+++ b/core/src/main/kotlin/org/taktik/icure/security/IcureLogContext.kt
@@ -1,0 +1,20 @@
+package org.taktik.icure.security
+
+/**
+ * Per-request log correlation triple carried in the Reactor Context.
+ *
+ * Populated at the WebFilter boundary by the cloud-side `HyperionRequestContextFilter`,
+ * read by the suspend log extensions in `LoggerUtils.kt` to decorate each event with
+ * matching SLF4J 2.0 key-value pairs. Plain data — not a `CoroutineContext.Element`;
+ * propagation rides on the existing `coroutineContext[ReactorContext]` channel that
+ * the codebase already uses for `SecurityContext`.
+ */
+data class IcureLogContext(
+	val requestId: String?,
+	val groupId: String?,
+	val userId: String?,
+) {
+	companion object {
+		val Key: Class<IcureLogContext> = IcureLogContext::class.java
+	}
+}

--- a/core/src/main/kotlin/org/taktik/icure/security/IcureLogContext.kt
+++ b/core/src/main/kotlin/org/taktik/icure/security/IcureLogContext.kt
@@ -20,6 +20,7 @@ data class IcureLogContext(
 	val requestId: String?,
 	val groupId: String?,
 	val userId: String?,
+	val targetGroupId: String? = null,
 ) {
 	companion object {
 		val Key: Class<IcureLogContext> = IcureLogContext::class.java

--- a/core/src/main/kotlin/org/taktik/icure/security/IcureLogContext.kt
+++ b/core/src/main/kotlin/org/taktik/icure/security/IcureLogContext.kt
@@ -1,13 +1,20 @@
 package org.taktik.icure.security
 
 /**
- * Per-request log correlation triple carried in the Reactor Context.
+ * Per-request log correlation triple carried in:
+ * - the Reactor Context (keyed by [Key]) — for suspend log extensions in `LoggerUtils.kt`
+ *   that read `currentCoroutineContext()[ReactorContext]?.context?.getOrDefault(Key, …)`;
+ * - the `ServerWebExchange.attributes` map (keyed by [EXCHANGE_ATTRIBUTE]) — for
+ *   synchronous Reactor-callback sites that have access to the exchange but not to the
+ *   coroutine context (notably `GlobalErrorHandler`, which runs as an
+ *   `ErrorWebExceptionHandler` after the filter chain unwinds and emits the bulk of the
+ *   error/warn logs in production).
  *
- * Populated at the WebFilter boundary by the cloud-side `HyperionRequestContextFilter`,
- * read by the suspend log extensions in `LoggerUtils.kt` to decorate each event with
- * matching SLF4J 2.0 key-value pairs. Plain data — not a `CoroutineContext.Element`;
- * propagation rides on the existing `coroutineContext[ReactorContext]` channel that
- * the codebase already uses for `SecurityContext`.
+ * Both channels are populated by the cloud-side `HyperionRequestContextFilter` at the
+ * top of the request and carry identical values.
+ *
+ * Plain data — not a `CoroutineContext.Element`. Propagation rides on the existing
+ * Reactor Context channel that the codebase already uses for `SecurityContext`.
  */
 data class IcureLogContext(
 	val requestId: String?,
@@ -16,5 +23,6 @@ data class IcureLogContext(
 ) {
 	companion object {
 		val Key: Class<IcureLogContext> = IcureLogContext::class.java
+		const val EXCHANGE_ATTRIBUTE: String = "org.taktik.icure.security.IcureLogContext"
 	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/security/LoggerUtils.kt
+++ b/core/src/main/kotlin/org/taktik/icure/security/LoggerUtils.kt
@@ -60,9 +60,11 @@ private suspend fun attachContext(builder: LoggingEventBuilder): LoggingEventBui
 	ctx.requestId?.let { builder.addKeyValue(KEY_REQUEST_ID, it) }
 	ctx.groupId?.let { builder.addKeyValue(KEY_GROUP_ID, it) }
 	ctx.userId?.let { builder.addKeyValue(KEY_USER_ID, it) }
+	ctx.targetGroupId?.let { builder.addKeyValue(KEY_TARGET_GROUP_ID, it) }
 	return builder
 }
 
 const val KEY_REQUEST_ID = "requestId"
 const val KEY_GROUP_ID = "groupId"
 const val KEY_USER_ID = "userId"
+const val KEY_TARGET_GROUP_ID = "targetGroupId"

--- a/core/src/main/kotlin/org/taktik/icure/security/LoggerUtils.kt
+++ b/core/src/main/kotlin/org/taktik/icure/security/LoggerUtils.kt
@@ -3,86 +3,66 @@
 package org.taktik.icure.security
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.reactor.ReactorContext
 import org.slf4j.Logger
-import org.slf4j.Marker
-import org.springframework.beans.factory.annotation.Autowired
+import org.slf4j.spi.LoggingEventBuilder
 
-interface LogMarker {
-	suspend fun getMarker(): Marker?
-}
-
-@Autowired
-private var logMarker: LogMarker? = null
+/**
+ * Suspend logger extensions that read [IcureLogContext] from the current Reactor Context
+ * (via the `ReactorContext` element in `coroutineContext`) and decorate each event with
+ * `requestId` / `groupId` / `userId` as SLF4J 2.0 key-value pairs.
+ *
+ * Single propagation channel: Reactor Context, the same mechanism the codebase already
+ * uses for `SecurityContext` (see `loadSecurityContext()` in this package). No MDC, no
+ * automatic-propagation hooks, no thread-local accessors.
+ *
+ * When no [IcureLogContext] is present (background tasks, scripts, `GlobalScope.launch`,
+ * unauthenticated request paths), events emit without correlation — the kraken-cloud
+ * Hyperion appender then drops them as untagged.
+ */
 
 suspend fun Logger.trace(msg: suspend () -> String) {
-	if (this.isTraceEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.trace(marker, msg())
-		} ?: this.trace(msg())
-	}
+	if (isTraceEnabled) attachContext(atTrace()).log(msg())
 }
 
 suspend fun Logger.debug(msg: suspend () -> String) {
-	if (this.isDebugEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.debug(marker, msg())
-		} ?: this.debug(msg())
-	}
+	if (isDebugEnabled) attachContext(atDebug()).log(msg())
 }
 
 suspend fun Logger.info(msg: suspend () -> String) {
-	if (this.isInfoEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.info(marker, msg())
-		} ?: this.info(msg())
-	}
+	if (isInfoEnabled) attachContext(atInfo()).log(msg())
 }
 
 suspend fun Logger.warn(msg: suspend () -> String) {
-	if (this.isWarnEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.warn(marker, msg())
-		} ?: this.warn(msg())
-	}
+	if (isWarnEnabled) attachContext(atWarn()).log(msg())
 }
 
 suspend fun Logger.error(msg: suspend () -> String) {
-	if (this.isErrorEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.error(marker, msg())
-		} ?: this.error(msg())
-	}
+	if (isErrorEnabled) attachContext(atError()).log(msg())
 }
 
-suspend fun Logger.info(
-	e: Throwable,
-	msg: suspend () -> String?,
-) {
-	if (this.isInfoEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.info(marker, msg() ?: e.message ?: e.localizedMessage, e)
-		} ?: this.info(msg(), e)
-	}
+suspend fun Logger.info(e: Throwable, msg: suspend () -> String?) {
+	if (isInfoEnabled) attachContext(atInfo()).setCause(e).log(msg() ?: e.message ?: e.localizedMessage)
 }
 
-suspend fun Logger.warn(
-	e: Throwable,
-	msg: suspend () -> String?,
-) {
-	if (this.isWarnEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.warn(marker, msg() ?: e.message ?: e.localizedMessage, e)
-		} ?: this.warn(msg(), e)
-	}
+suspend fun Logger.warn(e: Throwable, msg: suspend () -> String?) {
+	if (isWarnEnabled) attachContext(atWarn()).setCause(e).log(msg() ?: e.message ?: e.localizedMessage)
 }
 
-suspend fun Logger.error(
-	e: Throwable,
-	msg: suspend () -> String?,
-) {
-	if (this.isErrorEnabled) {
-		logMarker?.getMarker()?.let { marker ->
-			this.error(marker, msg() ?: e.message ?: e.localizedMessage, e)
-		} ?: this.error(msg(), e)
-	}
+suspend fun Logger.error(e: Throwable, msg: suspend () -> String?) {
+	if (isErrorEnabled) attachContext(atError()).setCause(e).log(msg() ?: e.message ?: e.localizedMessage)
 }
+
+private suspend fun attachContext(builder: LoggingEventBuilder): LoggingEventBuilder {
+	val reactor = currentCoroutineContext()[ReactorContext]?.context ?: return builder
+	val ctx = reactor.getOrDefault<IcureLogContext>(IcureLogContext.Key, null) ?: return builder
+	ctx.requestId?.let { builder.addKeyValue(KEY_REQUEST_ID, it) }
+	ctx.groupId?.let { builder.addKeyValue(KEY_GROUP_ID, it) }
+	ctx.userId?.let { builder.addKeyValue(KEY_USER_ID, it) }
+	return builder
+}
+
+const val KEY_REQUEST_ID = "requestId"
+const val KEY_GROUP_ID = "groupId"
+const val KEY_USER_ID = "userId"

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ServiceDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/ServiceDto.kt
@@ -49,7 +49,7 @@ data class ServiceDto(
 	val identifier: List<IdentifierDto> = emptyList(),
 	/** Id of the contact during which the service is provided. Only used when the Service is emitted outside of its contact */
 	@param:Schema(description = "Id of the contact during which the service is provided. Only used when the Service is emitted outside of its contact") val contactId: String? = null,
-	//List of IDs of all sub-contacts that link the service to structural elements. Only used when the Service is emitted outside of its contact",)
+	/** List of IDs of all sub-contacts that link the service to structural elements. Only used when the Service is emitted outside of its contact" */
 	@param:Schema(description = "List of IDs of all sub-contacts that link the service to structural elements. Only used when the Service is emitted outside of its contact",)
 	val subContactIds: Set<String>? = null, // Only used when the ServiceDto is emitted outside of its contact
 	/** List of IDs of all plans of actions (healthcare approaches) as a part of which the Service is provided. Only used when the Service is emitted outside of its contact */
@@ -61,8 +61,8 @@ data class ServiceDto(
 	/** List of Ids of all forms linked to the Service. Only used when the Service is emitted outside of its contact. */
 	@param:Schema(description = "List of Ids of all forms linked to the Service. Only used when the Service is emitted outside of its contact.")
 	val formIds: Set<String>? = null, // Only used when the ServiceDto is emitted outside of its contact
+	/** The secret patient key, encrypted in the patient document, in clear here. */
 	@param:Schema(
-		// "The secret patient key, encrypted in the patient document, in clear here.",
 		description = "The secret patient key, encrypted in the patient document, in clear here.",
 		defaultValue = "emptySet()"
 	)
@@ -91,9 +91,9 @@ data class ServiceDto(
 	/** The date (YYYYMMDDhhmmss) marking the end of the Service */
 	@param:Schema(description = "The date (YYYYMMDDhhmmss) marking the end of the Service") val closingDate: Long? = null, // YYYYMMDDHHMMSS if unknown, 00, ex:20010800000000. Note that to avoid all confusion: 2015/01/02 00:00:00 is encoded as 20140101235960.
 	@Deprecated("This field is deprecated for the use with Cardinal SDK")
-	/** Id of the form used during the Service */
+	/** Id of the form used during the Service, should never be used and should be replaced by subcontact grouping */
 	@param:Schema(description = "Id of the form used during the Service")
-	val formId: String? = null, // Used to group logically related services
+	val formId: String? = null,
 	/** The timestamp (unix epoch in ms) of creation of the service, will be filled automatically if missing. Not enforced by the application server. */
 	override val created: Long? = null,
 	/** The date (unix epoch in ms) of the latest modification of the service, will be filled automatically if missing. Not enforced by the application server. */


### PR DESCRIPTION
## Summary

- **New `IcureLogContext`** data class carrying the per-request correlation triple (`requestId`, `groupId`, `userId`) plus an optional **`targetGroupId`** captured from `…/inGroup/{id}` URL segments on the cloud side. Plain data placed in the Reactor Context by consumers (e.g. kraken-cloud's `HyperionRequestContextFilter`); not a `CoroutineContext.Element`.
- **`LoggerUtils.kt` rewritten** — suspend extensions now read `IcureLogContext` from `coroutineContext[ReactorContext]?.context?.getOrDefault(...)` and decorate each event via SLF4J 2.0 key-value pairs (`atWarn().addKeyValue(...).log(msg)`), using the same Reactor-Context channel the codebase already uses for `SecurityContext`. The new `KEY_TARGET_GROUP_ID` key is emitted alongside `requestId` / `groupId` / `userId` whenever set.
- **Fixes a latent bug**: the previous file-level `@Autowired private var logMarker: LogMarker?` compiled to a synthetic static field that Spring cannot autowire — the marker path was never invoked and every existing `log.x { ... }` callsite had been emitting without correlation since the wrapper was introduced.
- **`LogMarker` interface removed**. Consumers should switch from implementing `LogMarker` to populating `IcureLogContext` in the Reactor Context.

## Why

Pairs with the kraken-cloud Hyperion log-shipping work (icure/kraken-cloud#589). The previous interim approach used SLF4J MDC + `Hooks.enableAutomaticContextPropagation()` + custom `ThreadLocalAccessor` to bridge ThreadLocal MDC across Reactor scheduler boundaries; that design has well-known silent failure modes on raw `Executor`s, `GlobalScope.launch`, `CompletableFuture`, and `withContext(Dispatchers.IO)` without re-adding `MDCContext`. The new design uses the codebase's existing single-channel Reactor-Context idiom; no MDC, no ThreadLocalAccessor, no global hooks.

`targetGroupId` lets the consumer distinguish events emitted while operating on a different group than the session group (cross-group admin paths through `…/inGroup/{id}` controllers) without overloading the routing-key `groupId`.

## Test plan

- [ ] Existing suspend `log.x { ... }` callsites (e.g. in `CloudAuthenticationManagerImpl` on the cloud side) still compile and emit.
- [ ] Add a unit test on `LoggerUtils` (planned in a follow-up under the paired kraken-cloud PR) that verifies `addKeyValue(...)` is called when `IcureLogContext` is in the Reactor Context, and that the bare path is used when it's absent.
- [ ] The companion kraken-cloud PR's encoder tests cover `targetGroupId` fallback-to-groupId and KV-pair override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)