### PR TITLE
Add listReceiptsBetweenDates endpoint for receipts by creation date

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ReceiptDAOImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asyncdao/impl/ReceiptDAOImpl.kt
@@ -45,9 +45,23 @@ class ReceiptDAOImpl(
 	}
 
 	@View(name = "by_date", map = "function(doc) { if (doc.java_type === 'org.taktik.icure.entities.Receipt' && !doc.deleted) emit(doc.created)}")
-	override fun listReceiptsAfterDate(datastoreInformation: IDatastoreInformation, date: Long) = flow {
+	override fun listReceiptsBetweenDates(datastoreInformation: IDatastoreInformation, start: Long?, end: Long?, descending: Boolean) = flow {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
-		emitAll(client.queryViewIncludeDocs<String, String, Receipt>(createQuery(datastoreInformation, "by_date").startKey(999999999999L).endKey(date).descending(true).includeDocs(true)).map { it.doc })
+
+		val startKey =
+			if (descending) {
+				end ?: ComplexKey.emptyObject()
+			} else {
+				start
+			}
+		val endKey =
+			if (descending) {
+				start
+			} else {
+				end ?: ComplexKey.emptyObject()
+			}
+
+		emitAll(client.queryViewIncludeDocs<String, String, Receipt>(createQuery(datastoreInformation, "by_date").startKey(startKey).endKey(endKey).descending(descending).includeDocs(true)).map { it.doc })
 	}
 
 	@View(name = "by_category", map = "function(doc) { if (doc.java_type === 'org.taktik.icure.entities.Receipt' && !doc.deleted) emit([doc.category,doc.subCategory,doc.created])}")

--- a/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
+++ b/core/src/main/kotlin/org/taktik/icure/asynclogic/impl/ReceiptLogicImpl.kt
@@ -65,6 +65,11 @@ open class ReceiptLogicImpl(
 		emitAll(receiptDAO.listByReference(datastoreInformation, ref))
 	}
 
+	override fun listReceiptsBetweenDates(start: Long?, end: Long?, descending: Boolean): Flow<Receipt> = flow {
+		val datastoreInformation = getInstanceAndGroup()
+		emitAll(receiptDAO.listReceiptsBetweenDates(datastoreInformation, start, end, descending))
+	}
+
 	override fun getAttachment(
 		receiptId: String,
 		attachmentId: String,

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/support/ReceiptController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/support/ReceiptController.kt
@@ -275,6 +275,17 @@ class ReceiptController(
 		@PathVariable ref: String,
 	): Flux<ReceiptDto> = receiptService.listReceiptsByReference(ref).map { receiptV2Mapper.map(it) }.injectReactorContext()
 
+	@Operation(summary = "List Receipts created within the provided date range")
+	@GetMapping("/byCreated")
+	fun listReceiptsBetweenDates(
+		@Parameter(description = "The start search epoch (inclusive)") @RequestParam(required = false) startDate: Long?,
+		@Parameter(description = "The end search epoch (inclusive)") @RequestParam(required = false) endDate: Long?,
+		@Parameter(description = "Descending order") @RequestParam(required = false) descending: Boolean?,
+	): Flux<ReceiptDto> = receiptService
+		.listReceiptsBetweenDates(startDate, endDate, descending ?: false)
+		.map(receiptV2Mapper::map)
+		.injectReactorContext()
+
 	@Operation(summary = "Update a Receipt")
 	@PutMapping
 	fun modifyReceipt(

--- a/dao/src/main/kotlin/org/taktik/icure/asyncdao/ReceiptDAO.kt
+++ b/dao/src/main/kotlin/org/taktik/icure/asyncdao/ReceiptDAO.kt
@@ -13,7 +13,7 @@ interface ReceiptDAO :
 	AttachmentManagementDAO<Receipt> {
 	fun listByReference(datastoreInformation: IDatastoreInformation, ref: String): Flow<Receipt>
 
-	fun listReceiptsAfterDate(datastoreInformation: IDatastoreInformation, date: Long): Flow<Receipt>
+	fun listReceiptsBetweenDates(datastoreInformation: IDatastoreInformation, start: Long?, end: Long?, descending: Boolean): Flow<Receipt>
 
 	fun listReceiptsByCategory(datastoreInformation: IDatastoreInformation, category: String, subCategory: String, startDate: Long, endDate: Long): Flow<Receipt>
 

--- a/logic/src/main/kotlin/org/taktik/icure/asynclogic/ReceiptLogic.kt
+++ b/logic/src/main/kotlin/org/taktik/icure/asynclogic/ReceiptLogic.kt
@@ -18,6 +18,7 @@ interface ReceiptLogic :
 {
 	suspend fun createReceipt(receipt: Receipt): Receipt
 	fun listReceiptsByReference(ref: String): Flow<Receipt>
+	fun listReceiptsBetweenDates(start: Long?, end: Long?, descending: Boolean): Flow<Receipt>
 	fun getAttachment(receiptId: String, attachmentId: String): Flow<ByteBuffer>
 
 	/**

--- a/service/src/main/kotlin/org/taktik/icure/asyncservice/ReceiptService.kt
+++ b/service/src/main/kotlin/org/taktik/icure/asyncservice/ReceiptService.kt
@@ -25,6 +25,7 @@ interface ReceiptService :
 	fun modifyReceipts(receipts: List<Receipt>): Flow<Receipt>
 
 	fun listReceiptsByReference(ref: String): Flow<Receipt>
+	fun listReceiptsBetweenDates(start: Long?, end: Long?, descending: Boolean): Flow<Receipt>
 	fun getAttachment(receiptId: String, attachmentId: String): Flow<ByteBuffer>
 
 	suspend fun addReceiptAttachment(receipt: Receipt, blobType: ReceiptBlobType, payload: ByteArray): Receipt


### PR DESCRIPTION
## Summary
- Replaces `ReceiptDAO.listReceiptsAfterDate(date)` with the more flexible `listReceiptsBetweenDates(start, end, descending)`, with optional bounds.
- Exposes the new method through `ReceiptLogic` and `ReceiptService`.
- Adds a new v2 controller endpoint `GET /rest/v2/receipt/byCreated` taking optional `startDate`, `endDate`, and `descending` query parameters.

## Test plan
- [ ] Cloud-side e2e tests covering the new endpoint run green (see companion PR in `kraken-cloud`).
- [ ] Existing receipt-related tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)