### PR TITLE
Add support for sha1 2fa

### DIFF
--- a/core/src/main/kotlin/org/taktik/icure/security/AbstractAuthenticationManager.kt
+++ b/core/src/main/kotlin/org/taktik/icure/security/AbstractAuthenticationManager.kt
@@ -80,11 +80,9 @@ abstract class AbstractAuthenticationManager<
 	): Pair<JWT, Long?>
 
 	/**
-	 * Throws an exception if the username and password provided are unable to provide a valid token if passed to authentication methods.
-	 *
-	 * The purpose of the method is to validate if a user can still login after the addition of the 2FA to their user account.
+	 * IMPORTANT: this method checks the validity of authentication only against the local user, not safe for login.
 	 */
-	abstract suspend fun checkAuthentication(
+	abstract suspend fun checkAuthenticationLocal(
 		fullGroupAndId: String,
 		password: String,
 	)
@@ -240,4 +238,21 @@ abstract class AbstractAuthenticationManager<
 		.takeIf { it.size > 1 && it.last().length >= 6 && it.last().toLongOrNull() != null }
 		?.dropLast(1)
 		?.joinToString("|")
+
+	protected class ParsedTotpSecret(
+		val expectedCount: Int,
+		val secret: String,
+		val algorithm: ShaVersion
+	) {
+		companion object {
+			fun tryParse(secretString: String): ParsedTotpSecret? {
+				val parts = secretString.split(":")
+				if (parts.size != 3) return null
+				val expectedCount = parts[0].toIntOrNull() ?: return null
+				val secret = parts[1]
+				val algorithm = kotlin.runCatching { ShaVersion.valueOf(parts[2]) }.getOrNull() ?: return null
+				return ParsedTotpSecret(expectedCount, secret, algorithm)
+			}
+		}
+	}
 }

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/support/LoginController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/support/LoginController.kt
@@ -50,7 +50,6 @@ import reactor.core.publisher.Mono
 import java.util.UUID
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
-import kotlin.time.Duration.Companion.seconds
 
 @RestController
 @Profile("app")
@@ -149,7 +148,7 @@ class LoginController(
 		@RequestBody loginCredentials: LoginCredentials,
 	) = mono {
 		try {
-			authenticationManager.checkAuthentication(
+			authenticationManager.checkAuthenticationLocal(
 				loginCredentials.username ?: throw IllegalArgumentException("Username is required"),
 				loginCredentials.password ?: throw IllegalArgumentException("Password is required"),
 			)

--- a/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/support/LoginController.kt
+++ b/core/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/support/LoginController.kt
@@ -49,7 +49,6 @@ import org.taktik.icure.spring.asynccache.AsyncCacheManager
 import reactor.core.publisher.Mono
 import java.util.*
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 
 @RestController("loginControllerV2")
 @Profile("app")
@@ -151,7 +150,7 @@ class LoginController(
 		@RequestBody loginCredentials: LoginCredentials,
 	) = mono {
 		try {
-			authenticationManager.checkAuthentication(
+			authenticationManager.checkAuthenticationLocal(
 				loginCredentials.username ?: throw IllegalArgumentException("Username is required"),
 				loginCredentials.password ?: throw IllegalArgumentException("Password is required"),
 			)

--- a/domain/src/main/kotlin/org/taktik/icure/entities/User.kt
+++ b/domain/src/main/kotlin/org/taktik/icure/entities/User.kt
@@ -186,6 +186,10 @@ data class User(
 		 * True if the user mobile phone has been verified
 		 */
 		val verifiedMobilePhone: Boolean? = null,
+		/**
+		 * True if the user has 2fa enabled for login with password
+		 */
+		val uses2fa: Boolean? = null,
 	) : Serializable
 
 	/**

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/UserDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/UserDto.kt
@@ -96,5 +96,9 @@ data class UserDto(
 		val loginIdentifiers: List<IdentifierDto>,
 		val verifiedEmail: Boolean? = null,
 		val verifiedMobilePhone: Boolean? = null,
+		/**
+		 * True if the user has 2fa enabled for login with password
+		 */
+		val uses2fa: Boolean? = null,
 	) : Serializable
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/UserDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/UserDto.kt
@@ -138,5 +138,9 @@ data class UserDto(
 		@param:JsonInclude(JsonInclude.Include.NON_EMPTY) val loginIdentifiers: List<LoginIdentifierDto> = emptyList(),
 		val verifiedEmail: Boolean? = null,
 		val verifiedMobilePhone: Boolean? = null,
+		/**
+		 * True if the user has 2fa enabled for login with password
+		 */
+		val uses2fa: Boolean? = null,
 	) : Serializable
 }

--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/security/Enable2faRequestDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/security/Enable2faRequestDto.kt
@@ -11,4 +11,16 @@ data class Enable2faRequestDto(
 	val secret: String,
 	/** The number of digits in each generated one-time password. */
 	val otpLength: Int,
-)
+	/**
+	 * The otp at the current time for the provided configuration
+	 */
+	val otp: String,
+	/**
+	 * If null defaults to SHA1 as many authenticator apps still do not support different algorithms
+	 */
+	val algorithm: Algorithm? = null,
+) {
+	enum class Algorithm {
+		SHA1, SHA256, SHA512
+	}
+}

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -103,7 +103,7 @@ kotlinxSerializationJsonJvm = { group = "org.jetbrains.kotlinx", name = "kotlinx
 kotlinxSerializationJsonIo = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json-io", version.ref = "kotlinxSerialization" }
 kotlinxSerializationJsonIoJvm = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json-io-jvm", version.ref = "kotlinxSerialization" }
 kotlinxSerializationPlugin = { group = "org.jetbrains.kotlin.plugin.serialization", name = "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
-kotp = { group = "com.icure.kotp", name = "kotp", version = "1.0.2" } # 2FA
+kotp = { group = "com.icure.kotp", name = "kotp", version = "1.2.0" } # 2FA
 krouch = { group = "org.taktik.couchdb", name = "krouch", version = "1.2.84-g2440abd79b" }
 libRecur = { group = "org.dmfs", name = "lib-recur", version = "0.13.0" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.13.8" }


### PR DESCRIPTION
Many authenticator apps don't support the sha256 algorithm for generation of the token, the main purpose of this PR is to add support for token generation and validation using the sha1 algorithm, which is the most wide spread.

Additionally now requests to enable 2fa require that the client also passes the token: this will enforce the user to make sure that the authenticator app is properly configured before enabling 2fa that might lock the user out of their account