### PR TITLE
Restore options for DTOs v2

### DIFF
--- a/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/MedicationDto.kt
+++ b/dto/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/embed/MedicationDto.kt
@@ -51,7 +51,8 @@ data class MedicationDto(
 	val knownUsage: Boolean? = null,
 	val regimen: List<RegimenItemDto>? = null,
 	val posology: String? = null, // replace structured posology by text
-	// Obsolete and Evil, must go away, has been removed from here because it provokes a loop in mapping val options: Map<String, ContentDto>? = null,
+	@Deprecated("This field is deprecated for the use with Cardinal SDK")
+	val options: Map<String, ContentDto>? = null,
 	@Deprecated("This field is deprecated for the use with Cardinal SDK")
 	val agreements: Map<String, ParagraphAgreementDto>? = null,
 	@Deprecated("This field is deprecated for the use with Cardinal SDK")

--- a/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/embed/MedicationMapper.kt
+++ b/mapper/src/main/kotlin/org/taktik/icure/services/external/rest/v2/mapper/embed/MedicationMapper.kt
@@ -22,15 +22,20 @@ import org.mapstruct.InjectionStrategy
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.Mappings
+import org.taktik.icure.entities.embed.Content
 import org.taktik.icure.entities.embed.Medication
+import org.taktik.icure.services.external.rest.v2.dto.embed.ContentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.MedicationDto
 import org.taktik.icure.services.external.rest.v2.mapper.base.CodeStubV2Mapper
 
-@Mapper(componentModel = "spring", uses = [RenewalV2Mapper::class, MedicinalproductV2Mapper::class, CodeStubV2Mapper::class, RegimenItemV2Mapper::class, SuspensionV2Mapper::class, ParagraphAgreementV2Mapper::class, SubstanceproductV2Mapper::class, DurationV2Mapper::class, AddressV2Mapper::class], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@Mapper(componentModel = "spring", uses = [RenewalV2Mapper::class, MedicinalproductV2Mapper::class, CodeStubV2Mapper::class, RegimenItemV2Mapper::class, SuspensionV2Mapper::class, ParagraphAgreementV2Mapper::class, SubstanceproductV2Mapper::class, DurationV2Mapper::class, AddressV2Mapper::class, ServiceV2Mapper::class, MeasureV2Mapper::class, TimeSeriesV2Mapper::class, ], injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 interface MedicationV2Mapper {
 	@Mappings(
 		Mapping(target = "options", ignore = true),
 	)
 	fun map(medicationDto: MedicationDto): Medication
 	fun map(medication: Medication): MedicationDto
+
+	fun map(content: Content): ContentDto
+	fun map(contentDto: ContentDto): Content
 }


### PR DESCRIPTION
Because the Cardinal SDK legacy needs it for deserialisation